### PR TITLE
test: add comprehensive unit test suite with Docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,13 @@
 <p align="center">
   <a href="https://ntt-dkiku.github.io/chaos-eater/" target="_blank"><img src="https://img.shields.io/badge/project-page-green"></a>
   <a href="https://arxiv.org/abs/2501.11107" target="_blank"><img src="https://img.shields.io/badge/arXiv-pdf-red"></a>
-  <a href="https://alphaxiv.org/abs/2501.11107" target="_blank"><img src="https://img.shields.io/badge/alphaXiv-pdf-orange"></a>
-  <a href="https://huggingface.co/spaces/oookiku/chaos-eater" target="_blank"><img src="https://img.shields.io/badge/🤗-demo-yellow"></a>
   <a href="https://conf.researchr.org/home/ase-2025" target="_blank"><img src="https://img.shields.io/badge/ASE-2025-blue"></a>
 </p>
 
 <p>
   This repo is the official implementation of 
   
-  - LLM-Powered Fully Automated Chaos Engineering: Towards Enabling Anyone to Build Resilient Software Systems at Low Cost (to appear in ASE 2025, NIER track)
+  - <a href="https://arxiv.org/abs/2511.07865" target="_blank">LLM-Powered Fully Automated Chaos Engineering: Towards Enabling Anyone to Build Resilient Software Systems at Low Cost</a> (to appear in ASE 2025, NIER track)
   - <a href="https://arxiv.org/abs/2501.11107" target="_blank">ChaosEater: Fully Automating 
   Chaos Engineering with Large Language Models</a> (extended technical report)
   
@@ -84,11 +82,27 @@ Access `localhost:3000` in your browser, and you can try the ChaosEater GUI in y
 > [!TIP]  
 > If you are working on a remote server, don't forget to set up port forwarding, e.g., `ssh <remote-server-name> -L 3000:localhost:3000 -L 8000:localhost:8000 -L 2333:localhost:2333`.
 
-### Ex. Stop ChaosEater
+### EX1. Stop ChaosEater
 Run the following command to stop ChaosEater:
 ```
 make stop
 ```
+
+### EX2. Test ChaosEater (Experimental)
+Run unit tests with the following commands:
+```bash
+make test          # Run all unit tests
+make test-cov      # Run tests with coverage report
+```
+
+To run specific tests:
+```bash
+make test-file FILE=tests/test_api.py           # Run a specific test file
+make test-match PATTERN=test_parse              # Run tests matching a pattern
+```
+
+> [!TIP]
+> To run integration tests that require API keys, create `docker/.env` with your API keys and set `RUN_INTEGRATION_TESTS=1`.
 
 ## 🕹️ GUI usage
 <img src="./docs/static/images/gui_preview.png">
@@ -259,7 +273,6 @@ ChaosEater is built upon numerous excellent projects. Big thank you to the follo
 - LLM:
   - [Anthropic API](https://www.anthropic.com/api)
   - [Gemini API](https://ai.google.dev/)
-  - [Hugging Face](https://huggingface.co/)
   - [LangChain](https://github.com/langchain-ai/langchain)
   - [Ollama](https://github.com/ollama/ollama)
   - [OpenAI API](https://openai.com/index/openai-api/)

--- a/docker/docker-compose.test.yaml
+++ b/docker/docker-compose.test.yaml
@@ -1,0 +1,44 @@
+version: '3.8'
+
+services:
+  test:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile_llm
+    container_name: chaos-eater-test
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      - PATH=/app/.venv/bin:/usr/local/bin:/usr/bin:/bin
+      - PYTHONUNBUFFERED=1
+      - PYTHONDONTWRITEBYTECODE=1
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+    volumes:
+      - ..:/app/
+      - /app/.venv  # preserve venv from image
+    working_dir: /app
+    command: >
+      sh -c "uv sync --extra dev &&
+             pytest ${PYTEST_ARGS:---cov=chaos_eater --cov-report=term-missing}"
+
+  test-watch:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile_llm
+    container_name: chaos-eater-test-watch
+    environment:
+      - PATH=/app/.venv/bin:/usr/local/bin:/usr/bin:/bin
+      - PYTHONUNBUFFERED=1
+      - PYTHONDONTWRITEBYTECODE=1
+    volumes:
+      - ..:/app/
+      - /app/.venv
+    working_dir: /app
+    command: >
+      sh -c "uv sync --extra dev &&
+             pytest-watch -- --tb=short"
+    stdin_open: true
+    tty: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,19 @@ dependencies = [
     "tqdm>=4.67.1",
     "uvicorn[standard]>=0.38.0",
 ]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-cov>=4.1.0",
+    "pytest-asyncio>=0.23.0",
+    "httpx>=0.27.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+asyncio_mode = "auto"
+addopts = "-v --tb=short"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Run tests in Docker container
+#
+# Usage:
+#   ./scripts/test.sh                    # Run all tests with coverage
+#   ./scripts/test.sh tests/test_utils_functions.py  # Run specific test file
+#   ./scripts/test.sh -k "test_parse"    # Run tests matching pattern
+#   ./scripts/test.sh --help             # Show pytest help
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+# Build and run tests
+if [ $# -eq 0 ]; then
+    # No arguments: run all tests with coverage
+    docker compose -f docker/docker-compose.test.yaml run --rm test
+else
+    # Pass arguments to pytest
+    PYTEST_ARGS="$*" docker compose -f docker/docker-compose.test.yaml run --rm test
+fi

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,306 @@
+"""Unit tests for chaos_eater/backend/api.py"""
+import pytest
+from unittest.mock import Mock, patch, AsyncMock
+from datetime import datetime
+import asyncio
+
+from fastapi.testclient import TestClient
+
+
+class TestAPIModels:
+    """Tests for API Pydantic models"""
+
+    def test_job_status_enum(self):
+        from chaos_eater.backend.api import JobStatus
+        assert JobStatus.PENDING == "pending"
+        assert JobStatus.RUNNING == "running"
+        assert JobStatus.COMPLETED == "completed"
+        assert JobStatus.FAILED == "failed"
+        assert JobStatus.CANCELLED == "cancelled"
+        assert JobStatus.PAUSED == "paused"
+
+    def test_chaos_eater_job_request_with_project_path(self):
+        from chaos_eater.backend.api import ChaosEaterJobRequest
+        request = ChaosEaterJobRequest(
+            project_path="/path/to/project",
+            kube_context="kind-chaos-eater-cluster"
+        )
+        assert request.project_path == "/path/to/project"
+        assert request.input_data is None
+        assert request.kube_context == "kind-chaos-eater-cluster"
+
+    def test_chaos_eater_job_request_with_input_data(self):
+        from chaos_eater.backend.api import ChaosEaterJobRequest
+        request = ChaosEaterJobRequest(
+            input_data={"skaffold_yaml": {}, "files": []},
+            kube_context="kind-chaos-eater-cluster"
+        )
+        assert request.project_path is None
+        assert request.input_data is not None
+
+    def test_chaos_eater_job_request_validation_error(self):
+        from chaos_eater.backend.api import ChaosEaterJobRequest
+        from pydantic import ValidationError
+
+        # Both provided - should raise error
+        with pytest.raises(ValidationError):
+            ChaosEaterJobRequest(
+                project_path="/path",
+                input_data={"data": "test"},
+                kube_context="context"
+            )
+
+        # Neither provided - should raise error
+        with pytest.raises(ValidationError):
+            ChaosEaterJobRequest(kube_context="context")
+
+    def test_job_info_model(self):
+        from chaos_eater.backend.api import JobInfo, JobStatus
+        job = JobInfo(
+            job_id="test-123",
+            status=JobStatus.PENDING,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            progress="Test progress"
+        )
+        assert job.job_id == "test-123"
+        assert job.status == JobStatus.PENDING
+
+    def test_job_response_model(self):
+        from chaos_eater.backend.api import JobResponse, JobStatus
+        response = JobResponse(
+            job_id="test-123",
+            status=JobStatus.PENDING,
+            message="Job created",
+            work_dir="/sandbox/test"
+        )
+        assert response.job_id == "test-123"
+        assert response.work_dir == "/sandbox/test"
+
+
+class TestHelperFunctions:
+    """Tests for helper functions"""
+
+    def test_is_binary_bytes_text(self):
+        from chaos_eater.backend.api import _is_binary_bytes
+        text = b"Hello World\nThis is text content"
+        assert _is_binary_bytes(text) is False
+
+    def test_is_binary_bytes_binary(self):
+        from chaos_eater.backend.api import _is_binary_bytes
+        binary = b"\x00\x01\x02\x03\x04"
+        assert _is_binary_bytes(binary) is True
+
+    def test_read_text_or_binary_text(self, tmp_path):
+        from chaos_eater.backend.api import _read_text_or_binary
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("Hello World")
+        result = _read_text_or_binary(test_file)
+        assert isinstance(result, str)
+        assert result == "Hello World"
+
+    def test_read_text_or_binary_binary(self, tmp_path):
+        from chaos_eater.backend.api import _read_text_or_binary
+        test_file = tmp_path / "test.bin"
+        test_file.write_bytes(b"\x00\x01\x02\x03")
+        result = _read_text_or_binary(test_file)
+        assert isinstance(result, bytes)
+
+
+class TestJobManager:
+    """Tests for JobManager class"""
+
+    @pytest.fixture
+    def job_manager(self):
+        from chaos_eater.backend.api import JobManager
+        return JobManager()
+
+    @pytest.mark.asyncio
+    async def test_create_job(self, job_manager, tmp_path):
+        from chaos_eater.backend.api import ChaosEaterJobRequest
+        request = ChaosEaterJobRequest(
+            input_data={"skaffold_yaml": {}, "files": [], "ce_instructions": ""},
+            kube_context="test-context"
+        )
+
+        with patch.object(job_manager, '_save_job_to_disk'):
+            job_id = await job_manager.create_job(request)
+
+        assert job_id is not None
+        assert len(job_id) == 36  # UUID format
+
+    @pytest.mark.asyncio
+    async def test_get_job(self, job_manager):
+        from chaos_eater.backend.api import ChaosEaterJobRequest
+        request = ChaosEaterJobRequest(
+            input_data={"skaffold_yaml": {}, "files": [], "ce_instructions": ""},
+            kube_context="test-context"
+        )
+
+        with patch.object(job_manager, '_save_job_to_disk'):
+            job_id = await job_manager.create_job(request)
+
+        job = await job_manager.get_job(job_id)
+        assert job is not None
+        assert job.job_id == job_id
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_job(self, job_manager):
+        job = await job_manager.get_job("nonexistent-id")
+        assert job is None
+
+    @pytest.mark.asyncio
+    async def test_list_jobs(self, job_manager):
+        from chaos_eater.backend.api import ChaosEaterJobRequest
+        request = ChaosEaterJobRequest(
+            input_data={"skaffold_yaml": {}, "files": [], "ce_instructions": ""},
+            kube_context="test-context"
+        )
+
+        with patch.object(job_manager, '_save_job_to_disk'):
+            await job_manager.create_job(request)
+            await job_manager.create_job(request)
+
+        jobs = await job_manager.list_jobs()
+        assert len(jobs) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_jobs_with_status_filter(self, job_manager):
+        from chaos_eater.backend.api import ChaosEaterJobRequest, JobStatus
+        request = ChaosEaterJobRequest(
+            input_data={"skaffold_yaml": {}, "files": [], "ce_instructions": ""},
+            kube_context="test-context"
+        )
+
+        with patch.object(job_manager, '_save_job_to_disk'):
+            await job_manager.create_job(request)
+
+        # Filter by PENDING status
+        jobs = await job_manager.list_jobs(status=JobStatus.PENDING)
+        assert len(jobs) == 1
+
+        # Filter by RUNNING status - should be empty
+        jobs = await job_manager.list_jobs(status=JobStatus.RUNNING)
+        assert len(jobs) == 0
+
+
+class TestAPIEndpoints:
+    """Integration tests for API endpoints using TestClient"""
+
+    @pytest.fixture
+    def mock_job_manager(self):
+        from chaos_eater.backend.api import JobManager, JobInfo, JobStatus
+        manager = JobManager()
+        return manager
+
+    @pytest.fixture
+    def client(self, mock_job_manager):
+        from chaos_eater.backend.api import app, get_job_manager, get_llm, get_ce_tool
+
+        # Override dependencies
+        app.dependency_overrides[get_job_manager] = lambda: mock_job_manager
+        app.dependency_overrides[get_llm] = lambda: Mock()
+        app.dependency_overrides[get_ce_tool] = lambda: Mock()
+
+        client = TestClient(app)
+        yield client
+
+        # Clean up
+        app.dependency_overrides.clear()
+
+    def test_health_endpoint(self, client):
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+
+    def test_list_jobs_empty(self, client):
+        response = client.get("/jobs")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_get_nonexistent_job(self, client):
+        response = client.get("/jobs/nonexistent-job-id")
+        assert response.status_code == 404
+
+    @pytest.mark.skip(reason="Requires kubeconfig which is not available in test environment")
+    def test_get_clusters(self, client):
+        response = client.get("/clusters")
+        assert response.status_code == 200
+        data = response.json()
+        assert "available" in data
+        assert "claimed" in data
+
+
+class TestBuildInputFromProjectPath:
+    """Tests for build_input_from_project_path function"""
+
+    def test_project_path_not_found(self, tmp_path):
+        from chaos_eater.backend.api import build_input_from_project_path
+        with pytest.raises(FileNotFoundError):
+            build_input_from_project_path("/nonexistent/path")
+
+    def test_no_skaffold_yaml(self, tmp_path):
+        from chaos_eater.backend.api import build_input_from_project_path
+        # Create empty directory
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        with pytest.raises(FileNotFoundError):
+            build_input_from_project_path(str(project_dir))
+
+    def test_skaffold_no_manifests(self, tmp_path):
+        from chaos_eater.backend.api import build_input_from_project_path
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        skaffold = project_dir / "skaffold.yaml"
+        skaffold.write_text("apiVersion: skaffold/v2beta29\nkind: Config\n")
+
+        with pytest.raises(ValueError, match="no manifests.rawYaml"):
+            build_input_from_project_path(str(project_dir))
+
+    def test_valid_project_path(self, tmp_path):
+        from chaos_eater.backend.api import build_input_from_project_path
+        import yaml
+
+        # Create project structure
+        project_dir = tmp_path / "project"
+        k8s_dir = project_dir / "k8s"
+        project_dir.mkdir()
+        k8s_dir.mkdir()
+
+        # Create manifest
+        manifest_file = k8s_dir / "deployment.yaml"
+        manifest_file.write_text("apiVersion: apps/v1\nkind: Deployment\n")
+
+        # Create skaffold.yaml
+        skaffold_content = {
+            "apiVersion": "skaffold/v2beta29",
+            "kind": "Config",
+            "manifests": {
+                "rawYaml": ["k8s/deployment.yaml"]
+            }
+        }
+        skaffold = project_dir / "skaffold.yaml"
+        skaffold.write_text(yaml.dump(skaffold_content))
+
+        result = build_input_from_project_path(str(project_dir))
+
+        assert "skaffold_yaml" in result
+        assert "files" in result
+        assert len(result["files"]) == 1
+
+
+class TestSafeRmtree:
+    """Tests for _safe_rmtree function"""
+
+    def test_delete_outside_allowed_base(self, tmp_path):
+        from chaos_eater.backend.api import _safe_rmtree
+        result = _safe_rmtree("/some/random/path")
+        assert result["deleted"] is False
+        assert "denied" in result.get("reason", "")
+
+    def test_delete_nonexistent_path(self, tmp_path):
+        from chaos_eater.backend.api import _safe_rmtree
+        result = _safe_rmtree("/tmp/nonexistent-dir-12345")
+        assert result["deleted"] is False
+        assert "not found" in result.get("reason", "")

--- a/tests/test_ce_tools.py
+++ b/tests/test_ce_tools.py
@@ -1,0 +1,306 @@
+"""Unit tests for chaos_eater/ce_tools/"""
+import pytest
+
+
+class TestCEToolType:
+    """Tests for CEToolType enum"""
+
+    def test_chaosmesh_value(self):
+        from chaos_eater.ce_tools.ce_tool import CEToolType
+        assert CEToolType.chaosmesh.value == "chaosmesh"
+
+    def test_enum_members(self):
+        from chaos_eater.ce_tools.ce_tool import CEToolType
+        members = list(CEToolType)
+        assert len(members) >= 1
+        assert CEToolType.chaosmesh in members
+
+
+class TestCETool:
+    """Tests for CETool factory class"""
+
+    def test_init_chaosmesh(self):
+        from chaos_eater.ce_tools.ce_tool import CETool, CEToolType
+        from chaos_eater.ce_tools.chaosmesh.chaosmesh import ChaosMesh
+
+        tool = CETool.init(CEToolType.chaosmesh)
+        assert isinstance(tool, ChaosMesh)
+
+    def test_init_invalid_tool(self):
+        from chaos_eater.ce_tools.ce_tool import CETool
+
+        with pytest.raises(TypeError, match="Invalid chaos tool"):
+            CETool.init("invalid_tool")
+
+    def test_factory_map_exists(self):
+        from chaos_eater.ce_tools.ce_tool import CETool, CEToolType
+
+        assert CEToolType.chaosmesh in CETool.FACTORY_MAP
+
+
+class TestSelectors:
+    """Tests for Selectors schema"""
+
+    def test_selectors_with_namespaces(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        selector = Selectors(namespaces=["default", "chaos-eater"])
+        assert selector.namespaces == ["default", "chaos-eater"]
+
+    def test_selectors_with_label_selectors(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        selector = Selectors(labelSelectors={"app": "nginx", "tier": "frontend"})
+        assert selector.labelSelectors == {"app": "nginx", "tier": "frontend"}
+
+    def test_selectors_with_expression_selectors(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors, SetBasedRequirements
+
+        selector = Selectors(
+            expressionSelectors=[
+                SetBasedRequirements(key="tier", operator="In", values=["cache"])
+            ]
+        )
+        assert len(selector.expressionSelectors) == 1
+        assert selector.expressionSelectors[0].key == "tier"
+
+    def test_selectors_with_pods(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        selector = Selectors(pods={"default": ["pod-0", "pod-1"]})
+        assert "default" in selector.pods
+        assert len(selector.pods["default"]) == 2
+
+    def test_selectors_empty(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        selector = Selectors()
+        assert selector.namespaces is None
+        assert selector.labelSelectors is None
+
+
+class TestSetBasedRequirements:
+    """Tests for SetBasedRequirements schema"""
+
+    def test_in_operator(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import SetBasedRequirements
+
+        req = SetBasedRequirements(
+            key="environment",
+            operator="In",
+            values=["production", "staging"]
+        )
+        assert req.key == "environment"
+        assert req.operator == "In"
+        assert len(req.values) == 2
+
+    def test_exists_operator(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import SetBasedRequirements
+
+        req = SetBasedRequirements(
+            key="app",
+            operator="Exists",
+            values=[]
+        )
+        assert req.operator == "Exists"
+
+
+class TestPodChaos:
+    """Tests for PodChaos schema"""
+
+    def test_pod_kill_action(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.pod_chaos import PodChaos
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        chaos = PodChaos(
+            action="pod-kill",
+            mode="one",
+            selector=Selectors(namespaces=["default"])
+        )
+        assert chaos.action == "pod-kill"
+        assert chaos.mode == "one"
+
+    def test_container_kill_action(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.pod_chaos import PodChaos
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        chaos = PodChaos(
+            action="container-kill",
+            mode="all",
+            selector=Selectors(namespaces=["default"]),
+            containerNames=["nginx"]
+        )
+        assert chaos.action == "container-kill"
+        assert chaos.containerNames == ["nginx"]
+
+    def test_mode_options(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.pod_chaos import PodChaos
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        for mode in ["one", "all", "fixed", "fixed-percent", "random-max-percent"]:
+            chaos = PodChaos(
+                action="pod-kill",
+                mode=mode,
+                selector=Selectors(namespaces=["default"])
+            )
+            assert chaos.mode == mode
+
+    def test_with_value(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.pod_chaos import PodChaos
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        chaos = PodChaos(
+            action="pod-kill",
+            mode="fixed-percent",
+            value="50",
+            selector=Selectors(namespaces=["default"])
+        )
+        assert chaos.value == "50"
+
+
+class TestNetworkChaos:
+    """Tests for NetworkChaos schema"""
+
+    def test_delay_action(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import NetworkChaos, Deplay
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        chaos = NetworkChaos(
+            action="delay",
+            mode="all",
+            selector=Selectors(namespaces=["default"]),
+            delay=Deplay(latency="100ms", jitter="10ms")
+        )
+        assert chaos.action == "delay"
+        assert chaos.delay.latency == "100ms"
+
+    def test_loss_action(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import NetworkChaos, Loss
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        chaos = NetworkChaos(
+            action="loss",
+            mode="one",
+            selector=Selectors(namespaces=["default"]),
+            loss=Loss(loss="30", correlation="25")
+        )
+        assert chaos.action == "loss"
+        assert chaos.loss.loss == "30"
+
+    def test_bandwidth_action(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import NetworkChaos, Bandwidth
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        chaos = NetworkChaos(
+            action="bandwidth",
+            mode="all",
+            selector=Selectors(namespaces=["default"]),
+            bandwidth=Bandwidth(rate="1mbps", limit=100, buffer=100)
+        )
+        assert chaos.action == "bandwidth"
+        assert chaos.bandwidth.rate == "1mbps"
+
+    def test_direction_options(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import NetworkChaos
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        for direction in ["from", "to", "both"]:
+            chaos = NetworkChaos(
+                action="partition",
+                mode="one",
+                direction=direction,
+                selector=Selectors(namespaces=["default"])
+            )
+            assert chaos.direction == direction
+
+    def test_external_targets(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import NetworkChaos
+        from chaos_eater.ce_tools.chaosmesh.faults.selectors import Selectors
+
+        chaos = NetworkChaos(
+            action="partition",
+            mode="all",
+            direction="to",
+            selector=Selectors(namespaces=["default"]),
+            externalTargets=["1.1.1.1", "www.google.com"]
+        )
+        assert len(chaos.externalTargets) == 2
+
+
+class TestDelay:
+    """Tests for Delay schema"""
+
+    def test_basic_delay(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import Deplay
+
+        delay = Deplay(latency="50ms")
+        assert delay.latency == "50ms"
+
+    def test_delay_with_jitter(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import Deplay
+
+        delay = Deplay(latency="100ms", jitter="20ms")
+        assert delay.latency == "100ms"
+        assert delay.jitter == "20ms"
+
+    def test_delay_with_correlation(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import Deplay
+
+        delay = Deplay(latency="50ms", correlation="50")
+        assert delay.correlation == "50"
+
+
+class TestLoss:
+    """Tests for Loss schema"""
+
+    def test_basic_loss(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import Loss
+
+        loss = Loss(loss="25")
+        assert loss.loss == "25"
+
+    def test_loss_with_correlation(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import Loss
+
+        loss = Loss(loss="30", correlation="50")
+        assert loss.loss == "30"
+        assert loss.correlation == "50"
+
+
+class TestCorrupt:
+    """Tests for Corrupt schema"""
+
+    def test_basic_corrupt(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import Corrupt
+
+        corrupt = Corrupt(corrupt="10")
+        assert corrupt.corrupt == "10"
+
+
+class TestDuplicate:
+    """Tests for Duplicate schema"""
+
+    def test_basic_duplicate(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import Duplicate
+
+        dup = Duplicate(duplicate="15")
+        assert dup.duplicate == "15"
+
+
+class TestBandwidth:
+    """Tests for Bandwidth schema"""
+
+    def test_basic_bandwidth(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import Bandwidth
+
+        bw = Bandwidth(rate="10mbps", limit=1000, buffer=1000)
+        assert bw.rate == "10mbps"
+        assert bw.limit == 1000
+        assert bw.buffer == 1000
+
+    def test_bandwidth_with_optional_fields(self):
+        from chaos_eater.ce_tools.chaosmesh.faults.network_chaos import Bandwidth
+
+        bw = Bandwidth(rate="1gbps", limit=100, buffer=100, peakrate=1000, minburst=500)
+        assert bw.peakrate == 1000
+        assert bw.minburst == 500

--- a/tests/test_kustomize_input.py
+++ b/tests/test_kustomize_input.py
@@ -1,10 +1,15 @@
 import os
+import pytest
 from chaos_eater.preprocessing.preprocessor import PreProcessor, ChaosEaterInput
 from chaos_eater.utils.functions import is_binary
 from chaos_eater.utils.schemas import File
 from chaos_eater.utils.llms import load_llm
 
 
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY") or not os.getenv("RUN_INTEGRATION_TESTS"),
+    reason="OPENAI_API_KEY or RUN_INTEGRATION_TESTS not set"
+)
 def test_kustomize_input() -> None:
     #---------------------------
     # prepare a kustomize input 

--- a/tests/test_token_count.py
+++ b/tests/test_token_count.py
@@ -1,79 +1,383 @@
-import asyncio
-from typing import Dict
-
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_openai import ChatOpenAI
-from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_anthropic import ChatAnthropic
-
-from chaos_eater.utils.llms import TokenCounterCallback
+"""Unit tests for token counting and logging functionality in chaos_eater/utils/llms.py"""
+import os
+import tempfile
+import pytest
+from unittest.mock import Mock, MagicMock, patch
 
 
-def print_tokens(method: str, token_counter: Dict[str, int]) -> None:
-    input_tokens = token_counter['input_tokens']
-    output_tokens = token_counter['output_tokens']
-    total_tokens = token_counter['total_tokens']
-    print(f"{method} test:")
-    print(f"  - Input tokens: {input_tokens}")
-    print(f"  - Output tokens: {output_tokens}")
-    print(f"  - Total tokens: {total_tokens}")
-    assert input_tokens > 0
-    assert output_tokens > 0
-    assert total_tokens > 0
+class TestTokenUsage:
+    """Tests for TokenUsage model"""
 
-def load_chain(llm):
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", "You are a helpful AI assistant."),
-        ("user", "{input}")
-    ])
-    chain = prompt | llm
-    return chain
+    def test_create_token_usage(self):
+        from chaos_eater.utils.llms import TokenUsage
 
-def estimate_tokens(llm, input: str) -> Dict[str, int]:
-    chain = load_chain(llm)
-    # invoke test
-    token_counter = TokenCounterCallback(llm)
-    _ = chain.invoke({"input": input}, {"callbacks": [token_counter]})
-    print_tokens("invoke", token_counter.counter)
-    # stream test
-    token_counter = TokenCounterCallback(llm)
-    for _ in chain.stream({"input": input}, {"callbacks": [token_counter]}):
-        pass
-    print_tokens("stream", token_counter.counter)
+        usage = TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150)
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 50
+        assert usage.total_tokens == 150
 
-async def estimate_tokens_async(llm, input: str) -> Dict[str, int]:
-    # define chain
-    chain = load_chain(llm)
-    # ainvoke test
-    token_counter = TokenCounterCallback(llm)
-    await chain.ainvoke({"input": input}, {"callbacks": [token_counter]})
-    print_tokens("ainvoke", token_counter.counter)
-    # astream test
-    token_counter = TokenCounterCallback(llm)
-    async for _ in chain.astream({"input": input}, {"callbacks": [token_counter]}):
-        pass
-    print_tokens("astream", token_counter.counter)
+    def test_token_usage_defaults(self):
+        from chaos_eater.utils.llms import TokenUsage
 
-#-------
-# Tests
-#-------
-def test_gpt_token_count():
-    print()
-    print("GPT token count:")
-    gpt = ChatOpenAI(model="gpt-4o-2024-08-06", temperature=0)
-    estimate_tokens(gpt, "Hello!")
-    asyncio.run(estimate_tokens_async(gpt, "Hello!"))
+        usage = TokenUsage(input_tokens=0, output_tokens=0, total_tokens=0)
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.total_tokens == 0
 
-def test_gemini_token_count():
-    print()
-    print("Gemini token count:")
-    gemini = ChatGoogleGenerativeAI(model="gemini-1.5-pro", temperature=0)
-    estimate_tokens(gemini, "Hello!")
-    asyncio.run(estimate_tokens_async(gemini, "Hello!"))
 
-def test_claude_token_count():
-    print()
-    print("Claude token count:")
-    claude = ChatAnthropic(model="claude-3-5-sonnet-20240620", temperature=0)
-    estimate_tokens(claude, "Hello!")
-    asyncio.run(estimate_tokens_async(claude, "Hello!"))
+class TestLLMLog:
+    """Tests for LLMLog model"""
+
+    def test_create_llm_log(self):
+        from chaos_eater.utils.llms import LLMLog, TokenUsage
+
+        token_usage = TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150)
+        log = LLMLog(
+            agent_name="test_agent",
+            token_usage=token_usage,
+            message_history=["prompt1", "response1"]
+        )
+        assert log.agent_name == "test_agent"
+        assert log.token_usage.total_tokens == 150
+        assert len(log.message_history) == 2
+
+    def test_llm_log_empty_history(self):
+        from chaos_eater.utils.llms import LLMLog, TokenUsage
+
+        token_usage = TokenUsage(input_tokens=0, output_tokens=0, total_tokens=0)
+        log = LLMLog(
+            agent_name="empty_agent",
+            token_usage=token_usage,
+            message_history=[]
+        )
+        assert log.message_history == []
+
+
+class TestLogBundle:
+    """Tests for LogBundle model"""
+
+    def test_create_log_bundle(self):
+        from chaos_eater.utils.llms import LogBundle
+
+        bundle = LogBundle(logs={}, updated_at=1234567890.0)
+        assert bundle.logs == {}
+        assert bundle.updated_at == 1234567890.0
+
+    def test_log_bundle_with_logs(self):
+        from chaos_eater.utils.llms import LogBundle, LLMLog, TokenUsage
+
+        token_usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
+        log = LLMLog(agent_name="test", token_usage=token_usage, message_history=[])
+
+        bundle = LogBundle(logs={"phase1": [log]}, updated_at=0.0)
+        assert "phase1" in bundle.logs
+        assert len(bundle.logs["phase1"]) == 1
+
+
+class TestLoggingCallback:
+    """Tests for LoggingCallback class"""
+
+    def test_logging_callback_openai_model(self):
+        from chaos_eater.utils.llms import LoggingCallback
+
+        mock_llm = Mock()
+        mock_llm.__fields__ = {"model_name": Mock()}
+        mock_llm.model_name = "gpt-4o"
+
+        callback = LoggingCallback(agent_name="test_agent", llm=mock_llm, streaming=False)
+        assert callback.agent_name == "test_agent"
+        assert callback.model_provider == "openai"
+        assert callback.token_usage.total_tokens == 0
+
+    def test_logging_callback_anthropic_model(self):
+        from chaos_eater.utils.llms import LoggingCallback
+
+        mock_llm = Mock()
+        mock_llm.__fields__ = {"model": Mock()}
+        mock_llm.model = "claude-3-5-sonnet"
+
+        callback = LoggingCallback(agent_name="test_agent", llm=mock_llm, streaming=False)
+        assert callback.model_provider == "anthropic"
+
+    def test_logging_callback_google_model(self):
+        from chaos_eater.utils.llms import LoggingCallback
+
+        mock_llm = Mock()
+        mock_llm.__fields__ = {"model": Mock()}
+        mock_llm.model = "gemini-1.5-pro"
+
+        callback = LoggingCallback(agent_name="test_agent", llm=mock_llm, streaming=False)
+        assert callback.model_provider == "google"
+
+    def test_logging_callback_on_llm_start(self):
+        from chaos_eater.utils.llms import LoggingCallback
+
+        mock_llm = Mock()
+        mock_llm.__fields__ = {"model_name": Mock()}
+        mock_llm.model_name = "gpt-4o"
+
+        callback = LoggingCallback(agent_name="test_agent", llm=mock_llm, streaming=False)
+        callback.on_llm_start(serialized={}, prompts=["Hello, world!"])
+
+        assert len(callback.message_history) == 1
+        assert callback.message_history[0] == ["Hello, world!"]
+
+    def test_logging_callback_invalid_llm(self):
+        from chaos_eater.utils.llms import LoggingCallback
+
+        mock_llm = Mock()
+        mock_llm.__fields__ = {}
+
+        with pytest.raises(TypeError, match="Invalid llm"):
+            LoggingCallback(agent_name="test_agent", llm=mock_llm, streaming=False)
+
+
+class TestAgentLogger:
+    """Tests for AgentLogger class"""
+
+    def test_agent_logger_init(self):
+        from chaos_eater.utils.llms import AgentLogger
+
+        mock_llm = Mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "logs", "test.jsonl")
+            logger = AgentLogger(llm=mock_llm, log_path=log_path)
+
+            assert logger.llm == mock_llm
+            assert logger.log_path == log_path
+            assert os.path.exists(os.path.dirname(log_path))
+
+    def test_agent_logger_add_log(self):
+        from chaos_eater.utils.llms import AgentLogger, LLMLog, TokenUsage
+
+        mock_llm = Mock()
+        token_usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
+        log = LLMLog(agent_name="test", token_usage=token_usage, message_history=[])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "logs", "test.jsonl")
+            logger = AgentLogger(llm=mock_llm, log_path=log_path)
+            logger.add_log("hypothesis", log)
+
+            bundle = logger.get_bundle()
+            assert "hypothesis" in bundle.logs
+            assert len(bundle.logs["hypothesis"]) == 1
+
+    def test_agent_logger_add_logs(self):
+        from chaos_eater.utils.llms import AgentLogger, LLMLog, TokenUsage
+
+        mock_llm = Mock()
+        token_usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
+        logs = [
+            LLMLog(agent_name="test1", token_usage=token_usage, message_history=[]),
+            LLMLog(agent_name="test2", token_usage=token_usage, message_history=[])
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "logs", "test.jsonl")
+            logger = AgentLogger(llm=mock_llm, log_path=log_path)
+            logger.add_logs("experiment", logs)
+
+            bundle = logger.get_bundle()
+            assert len(bundle.logs["experiment"]) == 2
+
+    def test_agent_logger_get_phase(self):
+        from chaos_eater.utils.llms import AgentLogger, LLMLog, TokenUsage
+
+        mock_llm = Mock()
+        token_usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
+        log = LLMLog(agent_name="test", token_usage=token_usage, message_history=[])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "logs", "test.jsonl")
+            logger = AgentLogger(llm=mock_llm, log_path=log_path)
+            logger.add_log("analysis", log)
+
+            phase_logs = logger.get_phase("analysis")
+            assert len(phase_logs) == 1
+
+            empty_logs = logger.get_phase("nonexistent")
+            assert len(empty_logs) == 0
+
+    def test_agent_logger_jsonl_output(self):
+        from chaos_eater.utils.llms import AgentLogger, LLMLog, TokenUsage
+        import json
+
+        mock_llm = Mock()
+        token_usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
+        log = LLMLog(agent_name="test", token_usage=token_usage, message_history=["hello"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "logs", "test.jsonl")
+            logger = AgentLogger(llm=mock_llm, log_path=log_path)
+            logger.add_log("improvement", log)
+
+            with open(log_path, "r") as f:
+                line = f.readline()
+                event = json.loads(line)
+                assert event["type"] == "add_log"
+                assert event["phase"] == "improvement"
+                assert event["log"]["agent_name"] == "test"
+
+
+class TestAggregatingCallback:
+    """Tests for AggregatingCallback class"""
+
+    def test_aggregating_callback_on_llm_end(self):
+        from chaos_eater.utils.llms import AggregatingCallback, LoggingCallback, AgentLogger
+
+        mock_llm = Mock()
+        mock_llm.__fields__ = {"model_name": Mock()}
+        mock_llm.model_name = "gpt-4o"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "logs", "test.jsonl")
+            logger = AgentLogger(llm=mock_llm, log_path=log_path)
+
+            inner = LoggingCallback(agent_name="test", llm=mock_llm, streaming=False)
+            callback = AggregatingCallback(inner=inner, aggregator=logger, phase="hypothesis")
+
+            # Simulate on_llm_start
+            callback.on_llm_start(serialized={}, prompts=["test prompt"])
+
+            # Simulate on_llm_end with mock response
+            mock_generation = Mock()
+            mock_generation.text = "test response"
+            mock_generation.message = Mock()
+            mock_generation.message.response_metadata = {
+                "token_usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15
+                }
+            }
+
+            mock_response = Mock()
+            mock_response.generations = [[mock_generation]]
+
+            callback.on_llm_end(mock_response)
+
+            # Check that log was added to aggregator
+            phase_logs = logger.get_phase("hypothesis")
+            assert len(phase_logs) == 1
+
+
+class TestPricingPerToken:
+    """Tests for PRICING_PER_TOKEN dictionary"""
+
+    def test_pricing_dict_exists(self):
+        from chaos_eater.utils.llms import PRICING_PER_TOKEN
+
+        assert isinstance(PRICING_PER_TOKEN, dict)
+        assert len(PRICING_PER_TOKEN) > 0
+
+    def test_pricing_openai_gpt4o(self):
+        from chaos_eater.utils.llms import PRICING_PER_TOKEN
+
+        assert "openai/gpt-4o-2024-08-06" in PRICING_PER_TOKEN
+        pricing = PRICING_PER_TOKEN["openai/gpt-4o-2024-08-06"]
+        assert "input" in pricing
+        assert "output" in pricing
+        assert pricing["input"] > 0
+        assert pricing["output"] > 0
+
+    def test_pricing_anthropic_claude(self):
+        from chaos_eater.utils.llms import PRICING_PER_TOKEN
+
+        assert "anthropic/claude-3-5-sonnet-20241022" in PRICING_PER_TOKEN
+        pricing = PRICING_PER_TOKEN["anthropic/claude-3-5-sonnet-20241022"]
+        assert pricing["input"] > 0
+        assert pricing["output"] > 0
+
+    def test_pricing_google_gemini(self):
+        from chaos_eater.utils.llms import PRICING_PER_TOKEN
+
+        assert "google/gemini-1.5-pro" in PRICING_PER_TOKEN
+
+
+class TestVerifyApiKey:
+    """Tests for verify_api_key function"""
+
+    def test_verify_empty_key(self):
+        from chaos_eater.utils.llms import verify_api_key
+
+        assert verify_api_key("openai", "") is False
+        assert verify_api_key("openai", None) is False
+
+    @patch("chaos_eater.utils.llms.openai.OpenAI")
+    def test_verify_openai_invalid_key(self, mock_openai):
+        from chaos_eater.utils.llms import verify_api_key
+        import openai
+
+        mock_client = Mock()
+        mock_client.models.list.side_effect = openai.AuthenticationError(
+            message="Invalid API key",
+            response=Mock(),
+            body=None
+        )
+        mock_openai.return_value = mock_client
+
+        assert verify_api_key("openai", "invalid-key") is False
+
+    @patch("chaos_eater.utils.llms.openai.OpenAI")
+    def test_verify_openai_valid_key(self, mock_openai):
+        from chaos_eater.utils.llms import verify_api_key
+
+        mock_client = Mock()
+        mock_client.models.list.return_value = []
+        mock_openai.return_value = mock_client
+
+        assert verify_api_key("openai", "valid-key") is True
+
+
+class TestGetEnvKeyName:
+    """Tests for get_env_key_name function"""
+
+    def test_get_openai_key_name(self):
+        from chaos_eater.utils.llms import get_env_key_name
+
+        assert get_env_key_name("openai") == "OPENAI_API_KEY"
+
+    def test_get_google_key_name(self):
+        from chaos_eater.utils.llms import get_env_key_name
+
+        assert get_env_key_name("google") == "GOOGLE_API_KEY"
+
+    def test_get_anthropic_key_name(self):
+        from chaos_eater.utils.llms import get_env_key_name
+
+        assert get_env_key_name("anthropic") == "ANTHROPIC_API_KEY"
+
+    def test_get_unknown_provider(self):
+        from chaos_eater.utils.llms import get_env_key_name
+
+        assert get_env_key_name("unknown") == "API_KEY"
+
+
+class TestCheckExistingKey:
+    """Tests for check_existing_key function"""
+
+    @patch("chaos_eater.utils.llms.verify_api_key")
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_check_existing_valid_key(self, mock_verify):
+        from chaos_eater.utils.llms import check_existing_key
+
+        mock_verify.return_value = True
+        assert check_existing_key("openai") is True
+
+    @patch("chaos_eater.utils.llms.verify_api_key")
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "invalid-key"})
+    def test_check_existing_invalid_key(self, mock_verify):
+        from chaos_eater.utils.llms import check_existing_key
+
+        mock_verify.return_value = False
+        assert check_existing_key("openai") is False
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_check_no_existing_key(self):
+        from chaos_eater.utils.llms import check_existing_key
+
+        # Remove the key if it exists
+        os.environ.pop("OPENAI_API_KEY", None)
+        assert check_existing_key("openai") is False

--- a/tests/test_utils_functions.py
+++ b/tests/test_utils_functions.py
@@ -1,0 +1,486 @@
+"""Unit tests for chaos_eater/utils/functions.py"""
+import os
+import json
+import tempfile
+import shutil
+import pytest
+
+from chaos_eater.utils.functions import (
+    remove_spaces,
+    write_file,
+    read_file,
+    copy_file,
+    delete_file,
+    copy_dir,
+    save_json,
+    load_json,
+    save_jsonl,
+    load_jsonl,
+    extract_fname_wo_suffix,
+    remove_files_in,
+    make_artifact,
+    get_timestamp,
+    list_to_bullet_points,
+    add_code_fences,
+    sum_time,
+    parse_time,
+    add_timeunit,
+    int_to_ordinal,
+    dict_to_str,
+    remove_curly_braces,
+    get_file_extension,
+    sanitize_k8s_name,
+    sanitize_filename,
+    limit_string_length,
+    is_binary,
+    CLIDisplayHandler,
+    StreamDebouncer,
+    MessageLogger,
+)
+
+
+class TestRemoveSpaces:
+    def test_removes_leading_spaces(self):
+        text = "  hello\n  world"
+        assert remove_spaces(text) == "hello\nworld"
+
+    def test_removes_trailing_spaces(self):
+        text = "hello  \nworld  "
+        assert remove_spaces(text) == "hello\nworld"
+
+    def test_removes_both_spaces(self):
+        text = "  hello  \n  world  "
+        assert remove_spaces(text) == "hello\nworld"
+
+    def test_empty_string(self):
+        assert remove_spaces("") == ""
+
+    def test_only_spaces(self):
+        assert remove_spaces("   \n   ") == "\n"
+
+
+class TestFileOperations:
+    @pytest.fixture
+    def temp_dir(self):
+        """Create a temporary directory for tests"""
+        dirpath = tempfile.mkdtemp()
+        yield dirpath
+        shutil.rmtree(dirpath)
+
+    def test_write_and_read_file(self, temp_dir):
+        filepath = os.path.join(temp_dir, "test.txt")
+        content = "Hello, World!"
+        write_file(filepath, content)
+        assert read_file(filepath) == content
+
+    def test_write_file_unicode(self, temp_dir):
+        filepath = os.path.join(temp_dir, "unicode.txt")
+        content = "こんにちは世界"
+        write_file(filepath, content)
+        assert read_file(filepath) == content
+
+    def test_copy_file(self, temp_dir):
+        src = os.path.join(temp_dir, "source.txt")
+        dst = os.path.join(temp_dir, "subdir", "dest.txt")
+        content = "Copy me"
+        write_file(src, content)
+        copy_file(src, dst)
+        assert read_file(dst) == content
+
+    def test_delete_file_existing(self, temp_dir, capsys):
+        filepath = os.path.join(temp_dir, "delete_me.txt")
+        write_file(filepath, "delete")
+        delete_file(filepath)
+        assert not os.path.exists(filepath)
+        captured = capsys.readouterr()
+        assert "has been deleted" in captured.out
+
+    def test_delete_file_nonexistent(self, temp_dir, capsys):
+        filepath = os.path.join(temp_dir, "nonexistent.txt")
+        delete_file(filepath)
+        captured = capsys.readouterr()
+        assert "does not exist" in captured.out
+
+    def test_copy_dir_success(self, temp_dir, capsys):
+        src = os.path.join(temp_dir, "src_dir")
+        dst = os.path.join(temp_dir, "dst_dir")
+        os.makedirs(src)
+        write_file(os.path.join(src, "file.txt"), "content")
+        result = copy_dir(src, dst)
+        assert result is True
+        assert os.path.exists(os.path.join(dst, "file.txt"))
+
+    def test_copy_dir_source_not_exists(self, temp_dir, capsys):
+        src = os.path.join(temp_dir, "nonexistent")
+        dst = os.path.join(temp_dir, "dst")
+        result = copy_dir(src, dst)
+        assert result is False
+
+    def test_copy_dir_dest_exists(self, temp_dir, capsys):
+        src = os.path.join(temp_dir, "src")
+        dst = os.path.join(temp_dir, "dst")
+        os.makedirs(src)
+        os.makedirs(dst)
+        result = copy_dir(src, dst)
+        assert result is False
+
+
+class TestJsonOperations:
+    @pytest.fixture
+    def temp_dir(self):
+        dirpath = tempfile.mkdtemp()
+        yield dirpath
+        shutil.rmtree(dirpath)
+
+    def test_save_and_load_json(self, temp_dir):
+        filepath = os.path.join(temp_dir, "test.json")
+        data = {"key": "value", "number": 42, "nested": {"a": 1}}
+        save_json(filepath, data)
+        loaded = load_json(filepath)
+        assert loaded == data
+
+    def test_save_and_load_json_list(self, temp_dir):
+        filepath = os.path.join(temp_dir, "list.json")
+        data = [1, 2, 3, {"key": "value"}]
+        save_json(filepath, data)
+        loaded = load_json(filepath)
+        assert loaded == data
+
+    def test_save_and_load_jsonl(self, temp_dir):
+        filepath = os.path.join(temp_dir, "test.jsonl")
+        data = [
+            {"id": 1, "name": "Alice"},
+            {"id": 2, "name": "Bob"},
+            {"id": 3, "name": "日本語"},
+        ]
+        save_jsonl(filepath, data)
+        loaded = load_jsonl(filepath)
+        assert loaded == data
+
+    def test_jsonl_empty_list(self, temp_dir):
+        filepath = os.path.join(temp_dir, "empty.jsonl")
+        save_jsonl(filepath, [])
+        loaded = load_jsonl(filepath)
+        assert loaded == []
+
+
+class TestExtractFnameWoSuffix:
+    def test_simple_filename(self):
+        assert extract_fname_wo_suffix("/path/to/file.txt") == "file"
+
+    def test_multiple_dots(self):
+        assert extract_fname_wo_suffix("/path/to/file.test.py") == "file.test"
+
+    def test_no_extension(self):
+        assert extract_fname_wo_suffix("/path/to/file") == "file"
+
+    def test_hidden_file(self):
+        assert extract_fname_wo_suffix("/path/to/.gitignore") == ".gitignore"
+
+
+class TestMakeArtifact:
+    @pytest.fixture
+    def temp_dir(self):
+        dirpath = tempfile.mkdtemp()
+        yield dirpath
+        shutil.rmtree(dirpath)
+
+    def test_make_artifact_creates_zip(self, temp_dir):
+        src_dir = os.path.join(temp_dir, "source")
+        os.makedirs(src_dir)
+        write_file(os.path.join(src_dir, "file.txt"), "content")
+        dest_zip = os.path.join(temp_dir, "output", "archive.zip")
+        result = make_artifact(src_dir, dest_zip)
+        assert result.endswith(".zip")
+        assert os.path.exists(result)
+
+
+class TestRemoveFilesIn:
+    @pytest.fixture
+    def temp_dir(self):
+        dirpath = tempfile.mkdtemp()
+        yield dirpath
+        shutil.rmtree(dirpath)
+
+    def test_removes_all_files(self, temp_dir):
+        # Create nested structure
+        subdir = os.path.join(temp_dir, "sub")
+        os.makedirs(subdir)
+        write_file(os.path.join(temp_dir, "file1.txt"), "1")
+        write_file(os.path.join(subdir, "file2.txt"), "2")
+        remove_files_in(temp_dir)
+        # Files should be gone, directories remain
+        assert not os.path.exists(os.path.join(temp_dir, "file1.txt"))
+        assert not os.path.exists(os.path.join(subdir, "file2.txt"))
+        assert os.path.isdir(subdir)
+
+
+class TestGetTimestamp:
+    def test_format(self):
+        ts = get_timestamp()
+        # Should be YYYYMMDD_HHMMSS format
+        assert len(ts) == 15
+        assert ts[8] == "_"
+        assert ts[:8].isdigit()
+        assert ts[9:].isdigit()
+
+
+class TestTimeOperations:
+    class TestParseTime:
+        def test_seconds(self):
+            assert parse_time("30s") == 30
+
+        def test_minutes(self):
+            assert parse_time("5m") == 300
+
+        def test_hours(self):
+            assert parse_time("2h") == 7200
+
+        def test_combined(self):
+            assert parse_time("1h30m45s") == 5445
+
+        def test_zero(self):
+            assert parse_time("0") == 0
+
+    class TestAddTimeunit:
+        def test_zero(self):
+            assert add_timeunit(0) == "0"
+
+        def test_seconds_only(self):
+            assert add_timeunit(45) == "45s"
+
+        def test_minutes_and_seconds(self):
+            assert add_timeunit(125) == "2m5s"
+
+        def test_hours_minutes_seconds(self):
+            assert add_timeunit(3665) == "1h1m5s"
+
+        def test_days(self):
+            assert add_timeunit(90061) == "1d1h1m1s"
+
+    class TestSumTime:
+        def test_simple_sum(self):
+            assert sum_time("30s", "30s") == "1m"
+
+        def test_mixed_units(self):
+            assert sum_time("1h", "30m") == "1h30m"
+
+        def test_with_zero(self):
+            assert sum_time("5m", "0") == "5m"
+
+
+class TestIntToOrdinal:
+    def test_first(self):
+        assert int_to_ordinal(1) == "1st"
+
+    def test_second(self):
+        assert int_to_ordinal(2) == "2nd"
+
+    def test_third(self):
+        assert int_to_ordinal(3) == "3rd"
+
+    def test_fourth(self):
+        assert int_to_ordinal(4) == "4th"
+
+    def test_eleventh(self):
+        assert int_to_ordinal(11) == "11th"
+
+    def test_twelfth(self):
+        assert int_to_ordinal(12) == "12th"
+
+    def test_thirteenth(self):
+        assert int_to_ordinal(13) == "13th"
+
+    def test_twenty_first(self):
+        assert int_to_ordinal(21) == "21st"
+
+    def test_twenty_second(self):
+        assert int_to_ordinal(22) == "22nd"
+
+    def test_hundred_eleventh(self):
+        assert int_to_ordinal(111) == "111th"
+
+
+class TestStringOperations:
+    def test_dict_to_str(self):
+        result = dict_to_str({"key": "value"})
+        assert "{" not in result or "{{" in result
+        assert "}" not in result or "}}" in result
+
+    def test_remove_curly_braces(self):
+        text = "Hello {name}!"
+        result = remove_curly_braces(text)
+        assert result == "Hello {{name}}!"
+
+    def test_get_file_extension(self):
+        assert get_file_extension("file.txt") == ".txt"
+        assert get_file_extension("file.tar.gz") == ".gz"
+        assert get_file_extension("file") == ""
+
+    def test_list_to_bullet_points(self):
+        lst = ["item1", "item2", "item3"]
+        result = list_to_bullet_points(lst)
+        assert result == "- item1\n- item2\n- item3"
+
+    def test_list_to_bullet_points_empty(self):
+        assert list_to_bullet_points([]) == ""
+
+    def test_add_code_fences_no_header(self):
+        code = "print('hello')"
+        result = add_code_fences(code)
+        assert result == "```\nprint('hello')\n```"
+
+    def test_add_code_fences_with_header(self):
+        code = "print('hello')"
+        result = add_code_fences(code, "python")
+        assert result == "```python\nprint('hello')\n```"
+
+
+class TestSanitizeK8sName:
+    def test_lowercase(self):
+        assert sanitize_k8s_name("MyService") == "myservice"
+
+    def test_removes_invalid_chars(self):
+        assert sanitize_k8s_name("my_service@123") == "myservice123"
+
+    def test_removes_spaces(self):
+        assert sanitize_k8s_name("my service") == "myservice"
+
+    def test_removes_consecutive_hyphens(self):
+        assert sanitize_k8s_name("my--service") == "my-service"
+
+    def test_strips_leading_trailing_hyphens(self):
+        assert sanitize_k8s_name("-myservice-") == "myservice"
+
+    def test_empty_becomes_default(self):
+        assert sanitize_k8s_name("@#$%") == "default-name"
+
+    def test_truncates_to_63(self):
+        long_name = "a" * 100
+        result = sanitize_k8s_name(long_name)
+        assert len(result) == 63
+
+
+class TestSanitizeFilename:
+    def test_removes_invalid_chars(self):
+        assert sanitize_filename('file<>:"/\\|?*name.txt') == "filename.txt"
+
+    def test_removes_brackets(self):
+        assert sanitize_filename("file[test].txt") == "filetest.txt"
+
+    def test_removes_spaces(self):
+        assert sanitize_filename("my file.txt") == "myfile.txt"
+
+    def test_removes_consecutive_hyphens(self):
+        assert sanitize_filename("my--file.txt") == "my-file.txt"
+
+    def test_empty_becomes_default(self):
+        assert sanitize_filename("<>:?*") == "default-filename"
+
+    def test_truncates_to_255(self):
+        long_name = "a" * 300 + ".txt"
+        result = sanitize_filename(long_name)
+        assert len(result) == 255
+
+
+class TestLimitStringLength:
+    def test_short_string_unchanged(self):
+        s = "hello"
+        assert limit_string_length(s, 100) == s
+
+    def test_long_string_truncated(self):
+        s = "a" * 100
+        result = limit_string_length(s, 20)
+        assert len(result) <= 20
+        assert "..." in result
+
+    def test_preserves_start_and_end(self):
+        s = "START" + "x" * 100 + "END"
+        result = limit_string_length(s, 20)
+        assert result.startswith("STAR") or "START" in result[:10]
+
+    def test_suffix_longer_than_max(self):
+        result = limit_string_length("hello", 2, suffix="...")
+        assert result == "..."
+
+
+class TestIsBinary:
+    def test_text_content(self):
+        assert is_binary(b"Hello, World!") is False
+
+    def test_binary_with_null(self):
+        assert is_binary(b"Hello\x00World") is True
+
+    def test_high_byte_values(self):
+        assert is_binary(bytes([128, 129, 130])) is True
+
+    def test_empty_bytes(self):
+        assert is_binary(b"") is False
+
+
+class TestCLIDisplayHandler:
+    def test_on_start(self, capsys):
+        handler = CLIDisplayHandler()
+        handler.on_start("test command")
+        captured = capsys.readouterr()
+        assert "$ test command" in captured.out
+
+    def test_on_output(self, capsys):
+        handler = CLIDisplayHandler()
+        handler.on_output("output line")
+        captured = capsys.readouterr()
+        assert "output line" in captured.out
+
+    def test_on_error(self, capsys):
+        handler = CLIDisplayHandler()
+        handler.on_error("error message")
+        captured = capsys.readouterr()
+        assert "Error: error message" in captured.out
+
+
+class TestStreamDebouncer:
+    def test_first_call_returns_true(self):
+        debouncer = StreamDebouncer(interval=1.0)
+        assert debouncer.should_update() is True
+
+    def test_immediate_second_call_with_interval(self):
+        debouncer = StreamDebouncer(interval=1.0)
+        debouncer.should_update()
+        # Immediate second call should return False
+        assert debouncer.should_update() is False
+
+    def test_zero_interval_always_true(self):
+        debouncer = StreamDebouncer(interval=0)
+        assert debouncer.should_update() is True
+        assert debouncer.should_update() is True
+
+    def test_reset(self):
+        debouncer = StreamDebouncer(interval=1.0)
+        debouncer.should_update()
+        debouncer.reset()
+        assert debouncer.last_update_time == 0
+
+
+class TestMessageLogger:
+    @pytest.fixture
+    def temp_dir(self):
+        dirpath = tempfile.mkdtemp()
+        yield dirpath
+        shutil.rmtree(dirpath)
+
+    def test_save_empty(self, temp_dir):
+        logger = MessageLogger()
+        filepath = os.path.join(temp_dir, "messages.json")
+        logger.save(filepath)
+        with open(filepath) as f:
+            data = json.load(f)
+        assert data == []
+
+    def test_save_with_messages(self, temp_dir):
+        logger = MessageLogger()
+        logger.messages = [{"role": "user", "content": "hello"}]
+        filepath = os.path.join(temp_dir, "messages.json")
+        logger.save(filepath)
+        with open(filepath) as f:
+            data = json.load(f)
+        assert data == [{"role": "user", "content": "hello"}]

--- a/tests/test_utils_k8s.py
+++ b/tests/test_utils_k8s.py
@@ -1,0 +1,338 @@
+"""Unit tests for chaos_eater/utils/k8s.py"""
+import subprocess
+from unittest.mock import Mock, patch, MagicMock
+import pytest
+
+from chaos_eater.utils.k8s import (
+    kubectl_apply,
+    create_api_client,
+    check_deployment_status_by_label,
+    check_pod_status_by_label,
+    check_service_status_by_label,
+    check_job_status_by_label,
+    check_statefulset_status_by_label,
+    check_daemonset_status_by_label,
+    check_resources_status,
+    wait_for_resources_ready,
+    remove_all_resources_by_labels,
+    remove_all_resources_by_namespace,
+)
+
+
+class TestKubectlApply:
+    """Tests for kubectl_apply function"""
+
+    @patch('chaos_eater.utils.k8s.subprocess.run')
+    def test_apply_success(self, mock_run, capsys):
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout="deployment.apps/test created\n",
+            stderr=""
+        )
+        result = kubectl_apply("/path/to/manifest.yaml")
+        assert result is True
+        mock_run.assert_called_once_with(
+            ["kubectl", "apply", "-f", "/path/to/manifest.yaml"],
+            capture_output=True,
+            text=True
+        )
+
+    @patch('chaos_eater.utils.k8s.subprocess.run')
+    def test_apply_failure(self, mock_run, capsys):
+        mock_run.return_value = Mock(
+            returncode=1,
+            stdout="",
+            stderr="error: manifest not found"
+        )
+        result = kubectl_apply("/path/to/invalid.yaml")
+        assert result is False
+
+    @patch('chaos_eater.utils.k8s.subprocess.run')
+    def test_apply_exception(self, mock_run, capsys):
+        mock_run.side_effect = Exception("kubectl not found")
+        result = kubectl_apply("/path/to/manifest.yaml")
+        assert result is False
+
+
+class TestCreateApiClient:
+    """Tests for create_api_client function"""
+
+    @patch.dict('os.environ', {}, clear=True)
+    @patch('chaos_eater.utils.k8s.config.load_kube_config')
+    @patch('chaos_eater.utils.k8s.client.ApiClient')
+    @patch('chaos_eater.utils.k8s.client.Configuration')
+    def test_create_api_client_outside_cluster(
+        self, mock_config, mock_api_client, mock_load_kube_config, capsys
+    ):
+        # Remove KUBERNETES_SERVICE_HOST to simulate running outside cluster
+        import os
+        os.environ.pop('KUBERNETES_SERVICE_HOST', None)
+
+        mock_config.return_value = Mock()
+        mock_api_client.return_value = Mock()
+
+        result = create_api_client(context="test-context")
+
+        mock_load_kube_config.assert_called_once()
+        assert mock_api_client.called
+
+    @patch.dict('os.environ', {'KUBERNETES_SERVICE_HOST': '10.0.0.1'})
+    @patch('chaos_eater.utils.k8s.config.load_incluster_config')
+    @patch('chaos_eater.utils.k8s.client.ApiClient')
+    @patch('chaos_eater.utils.k8s.client.Configuration')
+    def test_create_api_client_inside_cluster(
+        self, mock_config, mock_api_client, mock_load_incluster_config, capsys
+    ):
+        mock_config.return_value = Mock()
+        mock_api_client.return_value = Mock()
+
+        result = create_api_client()
+
+        mock_load_incluster_config.assert_called_once()
+
+
+class TestCheckDeploymentStatusByLabel:
+    """Tests for check_deployment_status_by_label function"""
+
+    def test_all_replicas_available(self):
+        mock_api_client = Mock()
+        mock_deployment = Mock()
+        mock_deployment.metadata.name = "test-deployment"
+        mock_deployment.metadata.namespace = "default"
+        mock_deployment.status.available_replicas = 3
+        mock_deployment.spec.replicas = 3
+
+        mock_deployments = Mock()
+        mock_deployments.items = [mock_deployment]
+
+        with patch('chaos_eater.utils.k8s.client.AppsV1Api') as mock_apps_api:
+            mock_api = Mock()
+            mock_api.list_deployment_for_all_namespaces.return_value = mock_deployments
+            mock_apps_api.return_value = mock_api
+
+            result = check_deployment_status_by_label("app=test", mock_api_client)
+            assert result is True
+
+    def test_replicas_not_available(self):
+        mock_api_client = Mock()
+        mock_deployment = Mock()
+        mock_deployment.metadata.name = "test-deployment"
+        mock_deployment.metadata.namespace = "default"
+        mock_deployment.status.available_replicas = 1
+        mock_deployment.spec.replicas = 3
+
+        mock_deployments = Mock()
+        mock_deployments.items = [mock_deployment]
+
+        with patch('chaos_eater.utils.k8s.client.AppsV1Api') as mock_apps_api:
+            mock_api = Mock()
+            mock_api.list_deployment_for_all_namespaces.return_value = mock_deployments
+            mock_apps_api.return_value = mock_api
+
+            result = check_deployment_status_by_label("app=test", mock_api_client)
+            assert result is False
+
+
+class TestCheckPodStatusByLabel:
+    """Tests for check_pod_status_by_label function"""
+
+    def test_all_pods_running(self):
+        mock_api_client = Mock()
+        mock_pod = Mock()
+        mock_pod.metadata.name = "test-pod"
+        mock_pod.metadata.namespace = "default"
+        mock_pod.status.phase = "Running"
+
+        mock_pods = Mock()
+        mock_pods.items = [mock_pod]
+
+        with patch('chaos_eater.utils.k8s.client.CoreV1Api') as mock_core_api:
+            mock_api = Mock()
+            mock_api.list_pod_for_all_namespaces.return_value = mock_pods
+            mock_core_api.return_value = mock_api
+
+            result = check_pod_status_by_label("app=test", mock_api_client)
+            assert result is True
+
+    def test_pod_not_running(self):
+        mock_api_client = Mock()
+        mock_pod = Mock()
+        mock_pod.metadata.name = "test-pod"
+        mock_pod.metadata.namespace = "default"
+        mock_pod.status.phase = "Pending"
+
+        mock_pods = Mock()
+        mock_pods.items = [mock_pod]
+
+        with patch('chaos_eater.utils.k8s.client.CoreV1Api') as mock_core_api:
+            mock_api = Mock()
+            mock_api.list_pod_for_all_namespaces.return_value = mock_pods
+            mock_core_api.return_value = mock_api
+
+            result = check_pod_status_by_label("app=test", mock_api_client)
+            assert result is False
+
+
+class TestCheckServiceStatusByLabel:
+    """Tests for check_service_status_by_label function"""
+
+    def test_service_has_cluster_ip(self):
+        mock_api_client = Mock()
+        mock_service = Mock()
+        mock_service.metadata.name = "test-service"
+        mock_service.metadata.namespace = "default"
+        mock_service.spec.cluster_ip = "10.0.0.100"
+
+        mock_services = Mock()
+        mock_services.items = [mock_service]
+
+        with patch('chaos_eater.utils.k8s.client.CoreV1Api') as mock_core_api:
+            mock_api = Mock()
+            mock_api.list_service_for_all_namespaces.return_value = mock_services
+            mock_core_api.return_value = mock_api
+
+            result = check_service_status_by_label("app=test", mock_api_client)
+            assert result is True
+
+    def test_service_no_cluster_ip(self):
+        mock_api_client = Mock()
+        mock_service = Mock()
+        mock_service.metadata.name = "test-service"
+        mock_service.metadata.namespace = "default"
+        mock_service.spec.cluster_ip = None
+
+        mock_services = Mock()
+        mock_services.items = [mock_service]
+
+        with patch('chaos_eater.utils.k8s.client.CoreV1Api') as mock_core_api:
+            mock_api = Mock()
+            mock_api.list_service_for_all_namespaces.return_value = mock_services
+            mock_core_api.return_value = mock_api
+
+            result = check_service_status_by_label("app=test", mock_api_client)
+            assert result is False
+
+
+class TestCheckJobStatusByLabel:
+    """Tests for check_job_status_by_label function"""
+
+    def test_job_succeeded(self):
+        mock_api_client = Mock()
+        mock_job = Mock()
+        mock_job.metadata.name = "test-job"
+        mock_job.metadata.namespace = "default"
+        mock_job.status.succeeded = 1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_job]
+
+        with patch('chaos_eater.utils.k8s.client.BatchV1Api') as mock_batch_api:
+            mock_api = Mock()
+            mock_api.list_job_for_all_namespaces.return_value = mock_jobs
+            mock_batch_api.return_value = mock_api
+
+            result = check_job_status_by_label("app=test", mock_api_client)
+            assert result is True
+
+    def test_job_not_succeeded(self):
+        mock_api_client = Mock()
+        mock_job = Mock()
+        mock_job.metadata.name = "test-job"
+        mock_job.metadata.namespace = "default"
+        mock_job.status.succeeded = None
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_job]
+
+        with patch('chaos_eater.utils.k8s.client.BatchV1Api') as mock_batch_api:
+            mock_api = Mock()
+            mock_api.list_job_for_all_namespaces.return_value = mock_jobs
+            mock_batch_api.return_value = mock_api
+
+            result = check_job_status_by_label("app=test", mock_api_client)
+            assert result is False
+
+
+class TestCheckStatefulsetStatusByLabel:
+    """Tests for check_statefulset_status_by_label function"""
+
+    def test_statefulset_ready(self):
+        mock_api_client = Mock()
+        mock_statefulset = Mock()
+        mock_statefulset.metadata.name = "test-statefulset"
+        mock_statefulset.metadata.namespace = "default"
+        mock_statefulset.status.ready_replicas = 3
+        mock_statefulset.spec.replicas = 3
+
+        mock_statefulsets = Mock()
+        mock_statefulsets.items = [mock_statefulset]
+
+        with patch('chaos_eater.utils.k8s.client.AppsV1Api') as mock_apps_api:
+            mock_api = Mock()
+            mock_api.list_stateful_set_for_all_namespaces.return_value = mock_statefulsets
+            mock_apps_api.return_value = mock_api
+
+            result = check_statefulset_status_by_label("app=test", mock_api_client)
+            assert result is True
+
+
+class TestCheckDaemonsetStatusByLabel:
+    """Tests for check_daemonset_status_by_label function"""
+
+    def test_daemonset_ready(self):
+        mock_api_client = Mock()
+        mock_daemonset = Mock()
+        mock_daemonset.metadata.name = "test-daemonset"
+        mock_daemonset.metadata.namespace = "default"
+        mock_daemonset.status.number_available = 5
+        mock_daemonset.status.desired_number_scheduled = 5
+
+        mock_daemonsets = Mock()
+        mock_daemonsets.items = [mock_daemonset]
+
+        with patch('chaos_eater.utils.k8s.client.AppsV1Api') as mock_apps_api:
+            mock_api = Mock()
+            mock_api.list_daemon_set_for_all_namespaces.return_value = mock_daemonsets
+            mock_apps_api.return_value = mock_api
+
+            result = check_daemonset_status_by_label("app=test", mock_api_client)
+            assert result is True
+
+
+class TestRemoveAllResourcesByLabels:
+    """Tests for remove_all_resources_by_labels function"""
+
+    @patch('chaos_eater.utils.k8s.run_command')
+    def test_remove_resources_success(self, mock_run_command):
+        mock_run_command.return_value = None
+
+        mock_handler = Mock()
+        remove_all_resources_by_labels(
+            context="test-context",
+            label_selector="app=test",
+            display_handler=mock_handler
+        )
+
+        mock_run_command.assert_called_once()
+        call_args = mock_run_command.call_args
+        assert "kubectl delete all" in call_args.kwargs['cmd']
+        assert "test-context" in call_args.kwargs['cmd']
+        assert "app=test" in call_args.kwargs['cmd']
+
+
+class TestRemoveAllResourcesByNamespace:
+    """Tests for remove_all_resources_by_namespace function"""
+
+    @patch('chaos_eater.utils.k8s.run_command')
+    def test_remove_resources_by_namespace(self, mock_run_command):
+        mock_run_command.return_value = None
+
+        mock_handler = Mock()
+        remove_all_resources_by_namespace(
+            context="test-context",
+            namespace="test-namespace",
+            display_handler=mock_handler
+        )
+
+        # Should be called for each resource type
+        assert mock_run_command.call_count == 5  # workflow, workflownode, deployments, pods, services

--- a/tests/test_utils_llms.py
+++ b/tests/test_utils_llms.py
@@ -1,0 +1,402 @@
+"""Unit tests for chaos_eater/utils/llms.py"""
+import os
+import tempfile
+import shutil
+from unittest.mock import Mock, patch, MagicMock
+import pytest
+
+from chaos_eater.utils.llms import (
+    load_llm,
+    verify_model_name,
+    verify_api_key,
+    get_env_key_name,
+    check_existing_key,
+    TokenUsage,
+    LLMLog,
+    LogBundle,
+    AgentLogger,
+    LoggingCallback,
+    AggregatingCallback,
+    PRICING_PER_TOKEN,
+)
+
+
+class TestLoadLLM:
+    """Tests for load_llm function"""
+
+    @patch('chaos_eater.utils.llms.ChatOpenAI')
+    def test_load_openai_model(self, mock_openai):
+        mock_openai.return_value = Mock()
+        llm = load_llm("openai/gpt-4o", temperature=0.5, seed=123)
+        mock_openai.assert_called_once()
+        call_kwargs = mock_openai.call_args.kwargs
+        assert call_kwargs['model'] == 'gpt-4o'
+        assert call_kwargs['temperature'] == 0.5
+        assert call_kwargs['seed'] == 123
+
+    @patch('chaos_eater.utils.llms.ChatGoogleGenerativeAI')
+    def test_load_google_model(self, mock_google):
+        mock_google.return_value = Mock()
+        llm = load_llm("google/gemini-1.5-pro", temperature=0.3)
+        mock_google.assert_called_once()
+        call_kwargs = mock_google.call_args.kwargs
+        assert call_kwargs['model'] == 'gemini-1.5-pro'
+        assert call_kwargs['temperature'] == 0.3
+
+    @patch('chaos_eater.utils.llms.ChatAnthropic')
+    def test_load_anthropic_model(self, mock_anthropic):
+        mock_anthropic.return_value = Mock()
+        llm = load_llm("anthropic/claude-3-5-sonnet-20241022", temperature=0.7)
+        mock_anthropic.assert_called_once()
+        call_kwargs = mock_anthropic.call_args.kwargs
+        assert call_kwargs['model'] == 'claude-3-5-sonnet-20241022'
+        assert call_kwargs['temperature'] == 0.7
+
+    @patch('chaos_eater.utils.llms.verify_model_name')
+    @patch('chaos_eater.utils.llms.ChatOllama')
+    def test_load_ollama_model(self, mock_ollama, mock_verify):
+        mock_verify.return_value = True
+        mock_ollama.return_value = Mock()
+        llm = load_llm("ollama/llama3", temperature=0.0)
+        mock_ollama.assert_called_once()
+        call_kwargs = mock_ollama.call_args.kwargs
+        assert call_kwargs['model'] == 'llama3'
+
+    @patch('chaos_eater.utils.llms.verify_model_name')
+    def test_load_ollama_model_not_found(self, mock_verify):
+        mock_verify.return_value = False
+        from chaos_eater.utils.exceptions import ModelNotFoundError
+        with pytest.raises(ModelNotFoundError):
+            load_llm("ollama/nonexistent-model")
+
+    @patch('chaos_eater.utils.llms.ChatOpenAI')
+    def test_load_vllm_model(self, mock_openai):
+        """Test loading a custom VLLM model (no prefix)"""
+        mock_openai.return_value = Mock()
+        llm = load_llm("custom-model", port=8001)
+        mock_openai.assert_called_once()
+        call_kwargs = mock_openai.call_args.kwargs
+        assert call_kwargs['model'] == 'custom-model'
+        assert 'localhost:8001' in call_kwargs['openai_api_base']
+
+
+class TestVerifyModelName:
+    """Tests for verify_model_name function"""
+
+    @patch('chaos_eater.utils.llms.requests.get')
+    def test_model_exists(self, mock_get):
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "models": [{"name": "llama3"}, {"name": "mistral"}]
+        }
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = verify_model_name("llama3")
+        assert result is True
+
+    @patch('chaos_eater.utils.llms.requests.get')
+    def test_model_not_exists(self, mock_get):
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "models": [{"name": "llama3"}]
+        }
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = verify_model_name("nonexistent")
+        assert result is False
+
+    @patch('chaos_eater.utils.llms.requests.get')
+    def test_with_custom_base_url(self, mock_get):
+        mock_response = Mock()
+        mock_response.json.return_value = {"models": [{"name": "test"}]}
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        verify_model_name("test", base_url="http://custom:11434")
+        mock_get.assert_called_with("http://custom:11434/api/tags")
+
+
+class TestVerifyApiKey:
+    """Tests for verify_api_key function"""
+
+    def test_empty_api_key(self):
+        assert verify_api_key("openai", "") is False
+        assert verify_api_key("openai", None) is False
+
+    @patch('chaos_eater.utils.llms.openai.OpenAI')
+    def test_openai_valid_key(self, mock_openai_class):
+        mock_client = Mock()
+        mock_client.models.list.return_value = []
+        mock_openai_class.return_value = mock_client
+
+        result = verify_api_key("openai", "sk-valid-key")
+        assert result is True
+
+    @patch('chaos_eater.utils.llms.openai.OpenAI')
+    def test_openai_invalid_key(self, mock_openai_class):
+        import openai
+        mock_client = Mock()
+        mock_client.models.list.side_effect = openai.AuthenticationError(
+            message="Invalid API key",
+            response=Mock(status_code=401),
+            body=None
+        )
+        mock_openai_class.return_value = mock_client
+
+        result = verify_api_key("openai", "sk-invalid-key")
+        assert result is False
+
+    @patch('chaos_eater.utils.llms.requests.get')
+    def test_anthropic_valid_key(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        result = verify_api_key("anthropic", "sk-ant-valid")
+        assert result is True
+
+    @patch('chaos_eater.utils.llms.requests.get')
+    def test_anthropic_invalid_key(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 401
+        mock_get.return_value = mock_response
+
+        result = verify_api_key("anthropic", "sk-ant-invalid")
+        assert result is False
+
+    @patch('chaos_eater.utils.llms.requests.get')
+    def test_google_valid_key(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        result = verify_api_key("google", "valid-google-key")
+        assert result is True
+
+    @patch('chaos_eater.utils.llms.requests.get')
+    def test_google_invalid_key(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_get.return_value = mock_response
+
+        result = verify_api_key("google", "invalid-key")
+        assert result is False
+
+
+class TestGetEnvKeyName:
+    """Tests for get_env_key_name function"""
+
+    def test_openai(self):
+        assert get_env_key_name("openai") == "OPENAI_API_KEY"
+
+    def test_google(self):
+        assert get_env_key_name("google") == "GOOGLE_API_KEY"
+
+    def test_anthropic(self):
+        assert get_env_key_name("anthropic") == "ANTHROPIC_API_KEY"
+
+    def test_unknown_provider(self):
+        assert get_env_key_name("unknown") == "API_KEY"
+
+
+class TestCheckExistingKey:
+    """Tests for check_existing_key function"""
+
+    @patch('chaos_eater.utils.llms.verify_api_key')
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test-key"})
+    def test_existing_valid_key(self, mock_verify):
+        mock_verify.return_value = True
+        result = check_existing_key("openai")
+        assert result is True
+        mock_verify.assert_called_with("openai", "sk-test-key")
+
+    @patch('chaos_eater.utils.llms.verify_api_key')
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-invalid"})
+    def test_existing_invalid_key(self, mock_verify):
+        mock_verify.return_value = False
+        result = check_existing_key("openai")
+        assert result is False
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_existing_key(self):
+        # Clear the environment variable if it exists
+        os.environ.pop("OPENAI_API_KEY", None)
+        result = check_existing_key("openai")
+        assert result is False
+
+
+class TestTokenUsage:
+    """Tests for TokenUsage model"""
+
+    def test_create_token_usage(self):
+        usage = TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150)
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 50
+        assert usage.total_tokens == 150
+
+    def test_default_values(self):
+        usage = TokenUsage(input_tokens=0, output_tokens=0, total_tokens=0)
+        assert usage.input_tokens == 0
+
+
+class TestLLMLog:
+    """Tests for LLMLog model"""
+
+    def test_create_llm_log(self):
+        usage = TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150)
+        log = LLMLog(
+            agent_name="test_agent",
+            token_usage=usage,
+            message_history=[["user message"], "assistant response"]
+        )
+        assert log.agent_name == "test_agent"
+        assert log.token_usage.total_tokens == 150
+        assert len(log.message_history) == 2
+
+
+class TestLogBundle:
+    """Tests for LogBundle model"""
+
+    def test_create_empty_bundle(self):
+        bundle = LogBundle()
+        assert bundle.logs == {}
+        assert bundle.updated_at == 0.0
+
+    def test_create_bundle_with_logs(self):
+        usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
+        log = LLMLog(agent_name="test", token_usage=usage, message_history=[])
+        bundle = LogBundle(logs={"phase1": [log]}, updated_at=1234567890.0)
+        assert "phase1" in bundle.logs
+        assert len(bundle.logs["phase1"]) == 1
+
+
+class TestAgentLogger:
+    """Tests for AgentLogger class"""
+
+    @pytest.fixture
+    def temp_dir(self):
+        dirpath = tempfile.mkdtemp()
+        yield dirpath
+        shutil.rmtree(dirpath)
+
+    @pytest.fixture
+    def mock_llm(self):
+        llm = Mock()
+        llm.__fields__ = {"model_name": Mock()}
+        llm.model_name = "gpt-4o"
+        return llm
+
+    def test_init_creates_log_dir(self, temp_dir, mock_llm):
+        log_path = os.path.join(temp_dir, "subdir", "agent_log.jsonl")
+        logger = AgentLogger(llm=mock_llm, log_path=log_path)
+        assert os.path.exists(os.path.dirname(log_path))
+
+    def test_add_log(self, temp_dir, mock_llm):
+        log_path = os.path.join(temp_dir, "agent_log.jsonl")
+        logger = AgentLogger(llm=mock_llm, log_path=log_path)
+
+        usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
+        log = LLMLog(agent_name="test", token_usage=usage, message_history=[])
+
+        logger.add_log("phase1", log)
+
+        assert "phase1" in logger.bundle.logs
+        assert len(logger.bundle.logs["phase1"]) == 1
+
+    def test_add_logs(self, temp_dir, mock_llm):
+        log_path = os.path.join(temp_dir, "agent_log.jsonl")
+        logger = AgentLogger(llm=mock_llm, log_path=log_path)
+
+        usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
+        logs = [
+            LLMLog(agent_name="test1", token_usage=usage, message_history=[]),
+            LLMLog(agent_name="test2", token_usage=usage, message_history=[]),
+        ]
+
+        logger.add_logs("phase1", logs)
+
+        assert len(logger.bundle.logs["phase1"]) == 2
+
+    def test_get_phase(self, temp_dir, mock_llm):
+        log_path = os.path.join(temp_dir, "agent_log.jsonl")
+        logger = AgentLogger(llm=mock_llm, log_path=log_path)
+
+        usage = TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15)
+        log = LLMLog(agent_name="test", token_usage=usage, message_history=[])
+        logger.add_log("phase1", log)
+
+        phase_logs = logger.get_phase("phase1")
+        assert len(phase_logs) == 1
+
+        empty_logs = logger.get_phase("nonexistent")
+        assert len(empty_logs) == 0
+
+    def test_get_bundle(self, temp_dir, mock_llm):
+        log_path = os.path.join(temp_dir, "agent_log.jsonl")
+        logger = AgentLogger(llm=mock_llm, log_path=log_path)
+
+        bundle = logger.get_bundle()
+        assert isinstance(bundle, LogBundle)
+
+
+class TestLoggingCallback:
+    """Tests for LoggingCallback class"""
+
+    def test_init_with_openai_model(self):
+        llm = Mock()
+        llm.__fields__ = {"model_name": Mock()}
+        llm.model_name = "gpt-4o"
+
+        callback = LoggingCallback(agent_name="test", llm=llm, streaming=False)
+        assert callback.model_provider == "openai"
+        assert callback.agent_name == "test"
+
+    def test_init_with_google_model(self):
+        llm = Mock()
+        llm.__fields__ = {"model": Mock()}
+        llm.model = "gemini-1.5-pro"
+
+        callback = LoggingCallback(agent_name="test", llm=llm, streaming=False)
+        assert callback.model_provider == "google"
+
+    def test_init_with_anthropic_model(self):
+        llm = Mock()
+        llm.__fields__ = {"model": Mock()}
+        llm.model = "claude-3-5-sonnet"
+
+        callback = LoggingCallback(agent_name="test", llm=llm, streaming=False)
+        assert callback.model_provider == "anthropic"
+
+    def test_on_llm_start(self):
+        llm = Mock()
+        llm.__fields__ = {"model_name": Mock()}
+        llm.model_name = "gpt-4o"
+
+        callback = LoggingCallback(agent_name="test", llm=llm, streaming=False)
+        callback.on_llm_start(serialized={}, prompts=["Hello"])
+
+        assert len(callback.message_history) == 1
+        assert callback.message_history[0] == ["Hello"]
+
+
+class TestPricingPerToken:
+    """Tests for PRICING_PER_TOKEN constant"""
+
+    def test_openai_models_exist(self):
+        assert "openai/gpt-4o-2024-08-06" in PRICING_PER_TOKEN
+        assert "openai/gpt-4o-mini-2024-07-18" in PRICING_PER_TOKEN
+
+    def test_google_models_exist(self):
+        assert "google/gemini-1.5-pro-latest" in PRICING_PER_TOKEN
+
+    def test_anthropic_models_exist(self):
+        assert "anthropic/claude-3-5-sonnet-20241022" in PRICING_PER_TOKEN
+
+    def test_pricing_structure(self):
+        for model, pricing in PRICING_PER_TOKEN.items():
+            assert "input" in pricing
+            assert "output" in pricing
+            assert pricing["input"] > 0
+            assert pricing["output"] > 0

--- a/tests/test_utils_schemas.py
+++ b/tests/test_utils_schemas.py
@@ -1,0 +1,105 @@
+"""Unit tests for chaos_eater/utils/schemas.py"""
+import pytest
+
+from chaos_eater.utils.schemas import File
+
+
+class TestFileSchema:
+    """Tests for File schema"""
+
+    def test_create_file_with_string_content(self):
+        file = File(
+            path="/app/test.py",
+            content="print('hello')",
+            work_dir="/app",
+            fname="test.py"
+        )
+        assert file.path == "/app/test.py"
+        assert file.content == "print('hello')"
+        assert file.work_dir == "/app"
+        assert file.fname == "test.py"
+
+    def test_create_file_with_bytes_content(self):
+        file = File(
+            path="/app/image.png",
+            content=b"\x89PNG\r\n\x1a\n",
+            work_dir="/app",
+            fname="image.png"
+        )
+        assert file.path == "/app/image.png"
+        assert isinstance(file.content, bytes)
+
+    def test_create_file_with_optional_fields_none(self):
+        file = File(
+            path="/app/test.py",
+            content="content",
+            work_dir=None,
+            fname=None
+        )
+        assert file.path == "/app/test.py"
+        assert file.work_dir is None
+        assert file.fname is None
+
+    def test_file_dict_conversion(self):
+        file = File(
+            path="/app/test.py",
+            content="content",
+            work_dir="/app",
+            fname="test.py"
+        )
+        file_dict = file.dict()
+        assert file_dict["path"] == "/app/test.py"
+        assert file_dict["content"] == "content"
+        assert file_dict["work_dir"] == "/app"
+        assert file_dict["fname"] == "test.py"
+
+    def test_file_with_nested_path(self):
+        file = File(
+            path="/app/src/components/Button.tsx",
+            content="export const Button = () => {}",
+            work_dir="/app",
+            fname="src/components/Button.tsx"
+        )
+        assert file.path == "/app/src/components/Button.tsx"
+        assert file.fname == "src/components/Button.tsx"
+
+    def test_file_with_empty_content(self):
+        file = File(
+            path="/app/empty.txt",
+            content="",
+            work_dir="/app",
+            fname="empty.txt"
+        )
+        assert file.content == ""
+
+    def test_file_with_multiline_content(self):
+        content = """line 1
+line 2
+line 3"""
+        file = File(
+            path="/app/multiline.txt",
+            content=content,
+            work_dir="/app",
+            fname="multiline.txt"
+        )
+        assert file.content == content
+        assert file.content.count("\n") == 2
+
+    def test_file_with_unicode_content(self):
+        file = File(
+            path="/app/unicode.txt",
+            content="日本語テスト 🚀",
+            work_dir="/app",
+            fname="unicode.txt"
+        )
+        assert "日本語" in file.content
+        assert "🚀" in file.content
+
+    def test_file_with_special_characters_in_path(self):
+        file = File(
+            path="/app/test file (1).txt",
+            content="content",
+            work_dir="/app",
+            fname="test file (1).txt"
+        )
+        assert file.path == "/app/test file (1).txt"

--- a/uv.lock
+++ b/uv.lock
@@ -361,6 +361,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -532,10 +541,19 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "fastapi", specifier = ">=0.124.4" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "jupyterlab", specifier = ">=4.5.1" },
     { name = "kubernetes", specifier = "==30.1.0" },
@@ -551,6 +569,9 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pydantic", specifier = "==2.10.6" },
     { name = "pydot", specifier = ">=4.0.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "redis", specifier = ">=7.1.0" },
     { name = "scipy", specifier = ">=1.15.3" },
@@ -560,6 +581,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.38.0" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "charset-normalizer"
@@ -837,6 +859,110 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/59/ebfb8c677c75605cc27f7122c90313fd2f375ff3c8d19a1694bda74aaa63/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f9aad7de812d6541d29d2bbf8feb22ff7e1c299523db288004e3157ff4674e", size = 302202, upload-time = "2025-07-26T12:02:55.947Z" },
     { url = "https://files.pythonhosted.org/packages/3c/37/21972a15834d90bfbfb009b9d004779bd5a07a0ec0234e5ba8f64d5736f4/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989", size = 329207, upload-time = "2025-07-26T12:02:57.468Z" },
     { url = "https://files.pythonhosted.org/packages/0c/58/bd257695f39d05594ca4ad60df5bcb7e32247f9951fd09a9b8edb82d1daa/contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77", size = 225315, upload-time = "2025-07-26T12:02:58.801Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/45/2c665ca77ec32ad67e25c77daf1cee28ee4558f3bc571cdbaf88a00b9f23/coverage-7.13.0.tar.gz", hash = "sha256:a394aa27f2d7ff9bc04cf703817773a59ad6dfbd577032e690f961d2460ee936", size = 820905, upload-time = "2025-12-08T13:14:38.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/08/bdd7ccca14096f7eb01412b87ac11e5d16e4cb54b6e328afc9dee8bdaec1/coverage-7.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:02d9fb9eccd48f6843c98a37bd6817462f130b86da8660461e8f5e54d4c06070", size = 217979, upload-time = "2025-12-08T13:12:14.505Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/d1302e3416298a28b5663ae1117546a745d9d19fde7e28402b2c5c3e2109/coverage-7.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:367449cf07d33dc216c083f2036bb7d976c6e4903ab31be400ad74ad9f85ce98", size = 218496, upload-time = "2025-12-08T13:12:16.237Z" },
+    { url = "https://files.pythonhosted.org/packages/07/26/d36c354c8b2a320819afcea6bffe72839efd004b98d1d166b90801d49d57/coverage-7.13.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cdb3c9f8fef0a954c632f64328a3935988d33a6604ce4bf67ec3e39670f12ae5", size = 245237, upload-time = "2025-12-08T13:12:17.858Z" },
+    { url = "https://files.pythonhosted.org/packages/91/52/be5e85631e0eec547873d8b08dd67a5f6b111ecfe89a86e40b89b0c1c61c/coverage-7.13.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d10fd186aac2316f9bbb46ef91977f9d394ded67050ad6d84d94ed6ea2e8e54e", size = 247061, upload-time = "2025-12-08T13:12:19.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/45/a5e8fa0caf05fbd8fa0402470377bff09cc1f026d21c05c71e01295e55ab/coverage-7.13.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f88ae3e69df2ab62fb0bc5219a597cb890ba5c438190ffa87490b315190bb33", size = 248928, upload-time = "2025-12-08T13:12:20.702Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/42/ffb5069b6fd1b95fae482e02f3fecf380d437dd5a39bae09f16d2e2e7e01/coverage-7.13.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4be718e51e86f553bcf515305a158a1cd180d23b72f07ae76d6017c3cc5d791", size = 245931, upload-time = "2025-12-08T13:12:22.243Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/73e809b882c2858f13e55c0c36e94e09ce07e6165d5644588f9517efe333/coverage-7.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a00d3a393207ae12f7c49bb1c113190883b500f48979abb118d8b72b8c95c032", size = 246968, upload-time = "2025-12-08T13:12:23.52Z" },
+    { url = "https://files.pythonhosted.org/packages/87/08/64ebd9e64b6adb8b4a4662133d706fbaccecab972e0b3ccc23f64e2678ad/coverage-7.13.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3a7b1cd820e1b6116f92c6128f1188e7afe421c7e1b35fa9836b11444e53ebd9", size = 244972, upload-time = "2025-12-08T13:12:24.781Z" },
+    { url = "https://files.pythonhosted.org/packages/12/97/f4d27c6fe0cb375a5eced4aabcaef22de74766fb80a3d5d2015139e54b22/coverage-7.13.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:37eee4e552a65866f15dedd917d5e5f3d59805994260720821e2c1b51ac3248f", size = 245241, upload-time = "2025-12-08T13:12:28.041Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/94/42f8ae7f633bf4c118bf1038d80472f9dade88961a466f290b81250f7ab7/coverage-7.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:62d7c4f13102148c78d7353c6052af6d899a7f6df66a32bddcc0c0eb7c5326f8", size = 245847, upload-time = "2025-12-08T13:12:29.337Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/6369ca22b6b6d933f4f4d27765d313d8914cc4cce84f82a16436b1a233db/coverage-7.13.0-cp310-cp310-win32.whl", hash = "sha256:24e4e56304fdb56f96f80eabf840eab043b3afea9348b88be680ec5986780a0f", size = 220573, upload-time = "2025-12-08T13:12:30.905Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dc/a6a741e519acceaeccc70a7f4cfe5d030efc4b222595f0677e101af6f1f3/coverage-7.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:74c136e4093627cf04b26a35dab8cbfc9b37c647f0502fc313376e11726ba303", size = 221509, upload-time = "2025-12-08T13:12:32.09Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dc/888bf90d8b1c3d0b4020a40e52b9f80957d75785931ec66c7dfaccc11c7d/coverage-7.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0dfa3855031070058add1a59fdfda0192fd3e8f97e7c81de0596c145dea51820", size = 218104, upload-time = "2025-12-08T13:12:33.333Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ea/069d51372ad9c380214e86717e40d1a743713a2af191cfba30a0911b0a4a/coverage-7.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4fdb6f54f38e334db97f72fa0c701e66d8479af0bc3f9bfb5b90f1c30f54500f", size = 218606, upload-time = "2025-12-08T13:12:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/68/09/77b1c3a66c2aa91141b6c4471af98e5b1ed9b9e6d17255da5eb7992299e3/coverage-7.13.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7e442c013447d1d8d195be62852270b78b6e255b79b8675bad8479641e21fd96", size = 248999, upload-time = "2025-12-08T13:12:36.02Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/32/2e2f96e9d5691eaf1181d9040f850b8b7ce165ea10810fd8e2afa534cef7/coverage-7.13.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1ed5630d946859de835a85e9a43b721123a8a44ec26e2830b296d478c7fd4259", size = 250925, upload-time = "2025-12-08T13:12:37.221Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/45/b88ddac1d7978859b9a39a8a50ab323186148f1d64bc068f86fc77706321/coverage-7.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f15a931a668e58087bc39d05d2b4bf4b14ff2875b49c994bbdb1c2217a8daeb", size = 253032, upload-time = "2025-12-08T13:12:38.763Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cb/e15513f94c69d4820a34b6bf3d2b1f9f8755fa6021be97c7065442d7d653/coverage-7.13.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:30a3a201a127ea57f7e14ba43c93c9c4be8b7d17a26e03bb49e6966d019eede9", size = 249134, upload-time = "2025-12-08T13:12:40.382Z" },
+    { url = "https://files.pythonhosted.org/packages/09/61/d960ff7dc9e902af3310ce632a875aaa7860f36d2bc8fc8b37ee7c1b82a5/coverage-7.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7a485ff48fbd231efa32d58f479befce52dcb6bfb2a88bb7bf9a0b89b1bc8030", size = 250731, upload-time = "2025-12-08T13:12:41.992Z" },
+    { url = "https://files.pythonhosted.org/packages/98/34/c7c72821794afc7c7c2da1db8f00c2c98353078aa7fb6b5ff36aac834b52/coverage-7.13.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:22486cdafba4f9e471c816a2a5745337742a617fef68e890d8baf9f3036d7833", size = 248795, upload-time = "2025-12-08T13:12:43.331Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5b/e0f07107987a43b2def9aa041c614ddb38064cbf294a71ef8c67d43a0cdd/coverage-7.13.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:263c3dbccc78e2e331e59e90115941b5f53e85cfcc6b3b2fbff1fd4e3d2c6ea8", size = 248514, upload-time = "2025-12-08T13:12:44.546Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c2/c949c5d3b5e9fc6dd79e1b73cdb86a59ef14f3709b1d72bf7668ae12e000/coverage-7.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5330fa0cc1f5c3c4c3bb8e101b742025933e7848989370a1d4c8c5e401ea753", size = 249424, upload-time = "2025-12-08T13:12:45.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f1/bbc009abd6537cec0dffb2cc08c17a7f03de74c970e6302db4342a6e05af/coverage-7.13.0-cp311-cp311-win32.whl", hash = "sha256:0f4872f5d6c54419c94c25dd6ae1d015deeb337d06e448cd890a1e89a8ee7f3b", size = 220597, upload-time = "2025-12-08T13:12:47.378Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/d9977f2fb51c10fbaed0718ce3d0a8541185290b981f73b1d27276c12d91/coverage-7.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:51a202e0f80f241ccb68e3e26e19ab5b3bf0f813314f2c967642f13ebcf1ddfe", size = 221536, upload-time = "2025-12-08T13:12:48.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ad/3fcf43fd96fb43e337a3073dea63ff148dcc5c41ba7a14d4c7d34efb2216/coverage-7.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:d2a9d7f1c11487b1c69367ab3ac2d81b9b3721f097aa409a3191c3e90f8f3dd7", size = 220206, upload-time = "2025-12-08T13:12:50.365Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f1/2619559f17f31ba00fc40908efd1fbf1d0a5536eb75dc8341e7d660a08de/coverage-7.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0b3d67d31383c4c68e19a88e28fc4c2e29517580f1b0ebec4a069d502ce1e0bf", size = 218274, upload-time = "2025-12-08T13:12:52.095Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/11/30d71ae5d6e949ff93b2a79a2c1b4822e00423116c5c6edfaeef37301396/coverage-7.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:581f086833d24a22c89ae0fe2142cfaa1c92c930adf637ddf122d55083fb5a0f", size = 218638, upload-time = "2025-12-08T13:12:53.418Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c2/fce80fc6ded8d77e53207489d6065d0fed75db8951457f9213776615e0f5/coverage-7.13.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0a3a30f0e257df382f5f9534d4ce3d4cf06eafaf5192beb1a7bd066cb10e78fb", size = 250129, upload-time = "2025-12-08T13:12:54.744Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b6/51b5d1eb6fcbb9a1d5d6984e26cbe09018475c2922d554fd724dd0f056ee/coverage-7.13.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:583221913fbc8f53b88c42e8dbb8fca1d0f2e597cb190ce45916662b8b9d9621", size = 252885, upload-time = "2025-12-08T13:12:56.401Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/972a5affea41de798691ab15d023d3530f9f56a72e12e243f35031846ff7/coverage-7.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f5d9bd30756fff3e7216491a0d6d520c448d5124d3d8e8f56446d6412499e74", size = 253974, upload-time = "2025-12-08T13:12:57.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/56/116513aee860b2c7968aa3506b0f59b22a959261d1dbf3aea7b4450a7520/coverage-7.13.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a23e5a1f8b982d56fa64f8e442e037f6ce29322f1f9e6c2344cd9e9f4407ee57", size = 250538, upload-time = "2025-12-08T13:12:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/75/074476d64248fbadf16dfafbf93fdcede389ec821f74ca858d7c87d2a98c/coverage-7.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b01c22bc74a7fb44066aaf765224c0d933ddf1f5047d6cdfe4795504a4493f8", size = 251912, upload-time = "2025-12-08T13:13:00.604Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d2/aa4f8acd1f7c06024705c12609d8698c51b27e4d635d717cd1934c9668e2/coverage-7.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:898cce66d0836973f48dda4e3514d863d70142bdf6dfab932b9b6a90ea5b222d", size = 250054, upload-time = "2025-12-08T13:13:01.892Z" },
+    { url = "https://files.pythonhosted.org/packages/19/98/8df9e1af6a493b03694a1e8070e024e7d2cdc77adedc225a35e616d505de/coverage-7.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3ab483ea0e251b5790c2aac03acde31bff0c736bf8a86829b89382b407cd1c3b", size = 249619, upload-time = "2025-12-08T13:13:03.236Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/71/f8679231f3353018ca66ef647fa6fe7b77e6bff7845be54ab84f86233363/coverage-7.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d84e91521c5e4cb6602fe11ece3e1de03b2760e14ae4fcf1a4b56fa3c801fcd", size = 251496, upload-time = "2025-12-08T13:13:04.511Z" },
+    { url = "https://files.pythonhosted.org/packages/04/86/9cb406388034eaf3c606c22094edbbb82eea1fa9d20c0e9efadff20d0733/coverage-7.13.0-cp312-cp312-win32.whl", hash = "sha256:193c3887285eec1dbdb3f2bd7fbc351d570ca9c02ca756c3afbc71b3c98af6ef", size = 220808, upload-time = "2025-12-08T13:13:06.422Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/59/af483673df6455795daf5f447c2f81a3d2fcfc893a22b8ace983791f6f34/coverage-7.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:4f3e223b2b2db5e0db0c2b97286aba0036ca000f06aca9b12112eaa9af3d92ae", size = 221616, upload-time = "2025-12-08T13:13:07.95Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b0/959d582572b30a6830398c60dd419c1965ca4b5fb38ac6b7093a0d50ca8d/coverage-7.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:086cede306d96202e15a4b77ace8472e39d9f4e5f9fd92dd4fecdfb2313b2080", size = 220261, upload-time = "2025-12-08T13:13:09.581Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/cc/bce226595eb3bf7d13ccffe154c3c487a22222d87ff018525ab4dd2e9542/coverage-7.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:28ee1c96109974af104028a8ef57cec21447d42d0e937c0275329272e370ebcf", size = 218297, upload-time = "2025-12-08T13:13:10.977Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/9f/73c4d34600aae03447dff3d7ad1d0ac649856bfb87d1ca7d681cfc913f9e/coverage-7.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e97353dcc5587b85986cda4ff3ec98081d7e84dd95e8b2a6d59820f0545f8a", size = 218673, upload-time = "2025-12-08T13:13:12.562Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ab/8fa097db361a1e8586535ae5073559e6229596b3489ec3ef2f5b38df8cb2/coverage-7.13.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:99acd4dfdfeb58e1937629eb1ab6ab0899b131f183ee5f23e0b5da5cba2fec74", size = 249652, upload-time = "2025-12-08T13:13:13.909Z" },
+    { url = "https://files.pythonhosted.org/packages/90/3a/9bfd4de2ff191feb37ef9465855ca56a6f2f30a3bca172e474130731ac3d/coverage-7.13.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ff45e0cd8451e293b63ced93161e189780baf444119391b3e7d25315060368a6", size = 252251, upload-time = "2025-12-08T13:13:15.553Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/b5d8105f016e1b5874af0d7c67542da780ccd4a5f2244a433d3e20ceb1ad/coverage-7.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4f72a85316d8e13234cafe0a9f81b40418ad7a082792fa4165bd7d45d96066b", size = 253492, upload-time = "2025-12-08T13:13:16.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b8/0fad449981803cc47a4694768b99823fb23632150743f9c83af329bb6090/coverage-7.13.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:11c21557d0e0a5a38632cbbaca5f008723b26a89d70db6315523df6df77d6232", size = 249850, upload-time = "2025-12-08T13:13:18.142Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e9/8d68337c3125014d918cf4327d5257553a710a2995a6a6de2ac77e5aa429/coverage-7.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76541dc8d53715fb4f7a3a06b34b0dc6846e3c69bc6204c55653a85dd6220971", size = 251633, upload-time = "2025-12-08T13:13:19.56Z" },
+    { url = "https://files.pythonhosted.org/packages/55/14/d4112ab26b3a1bc4b3c1295d8452dcf399ed25be4cf649002fb3e64b2d93/coverage-7.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6e9e451dee940a86789134b6b0ffbe31c454ade3b849bb8a9d2cca2541a8e91d", size = 249586, upload-time = "2025-12-08T13:13:20.883Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a9/22b0000186db663b0d82f86c2f1028099ae9ac202491685051e2a11a5218/coverage-7.13.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5c67dace46f361125e6b9cace8fe0b729ed8479f47e70c89b838d319375c8137", size = 249412, upload-time = "2025-12-08T13:13:22.22Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/2e/42d8e0d9e7527fba439acdc6ed24a2b97613b1dc85849b1dd935c2cffef0/coverage-7.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f59883c643cb19630500f57016f76cfdcd6845ca8c5b5ea1f6e17f74c8e5f511", size = 251191, upload-time = "2025-12-08T13:13:23.899Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/af/8c7af92b1377fd8860536aadd58745119252aaaa71a5213e5a8e8007a9f5/coverage-7.13.0-cp313-cp313-win32.whl", hash = "sha256:58632b187be6f0be500f553be41e277712baa278147ecb7559983c6d9faf7ae1", size = 220829, upload-time = "2025-12-08T13:13:25.182Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f9/725e8bf16f343d33cbe076c75dc8370262e194ff10072c0608b8e5cf33a3/coverage-7.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:73419b89f812f498aca53f757dd834919b48ce4799f9d5cad33ca0ae442bdb1a", size = 221640, upload-time = "2025-12-08T13:13:26.836Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ff/e98311000aa6933cc79274e2b6b94a2fe0fe3434fca778eba82003675496/coverage-7.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:eb76670874fdd6091eedcc856128ee48c41a9bbbb9c3f1c7c3cf169290e3ffd6", size = 220269, upload-time = "2025-12-08T13:13:28.116Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cf/bbaa2e1275b300343ea865f7d424cc0a2e2a1df6925a070b2b2d5d765330/coverage-7.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6e63ccc6e0ad8986386461c3c4b737540f20426e7ec932f42e030320896c311a", size = 218990, upload-time = "2025-12-08T13:13:29.463Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1d/82f0b3323b3d149d7672e7744c116e9c170f4957e0c42572f0366dbb4477/coverage-7.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:494f5459ffa1bd45e18558cd98710c36c0b8fbfa82a5eabcbe671d80ecffbfe8", size = 219340, upload-time = "2025-12-08T13:13:31.524Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e3/fe3fd4702a3832a255f4d43013eacb0ef5fc155a5960ea9269d8696db28b/coverage-7.13.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:06cac81bf10f74034e055e903f5f946e3e26fc51c09fc9f584e4a1605d977053", size = 260638, upload-time = "2025-12-08T13:13:32.965Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/01/63186cb000307f2b4da463f72af9b85d380236965574c78e7e27680a2593/coverage-7.13.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f2ffc92b46ed6e6760f1d47a71e56b5664781bc68986dbd1836b2b70c0ce2071", size = 262705, upload-time = "2025-12-08T13:13:34.378Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a1/c0dacef0cc865f2455d59eed3548573ce47ed603205ffd0735d1d78b5906/coverage-7.13.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0602f701057c6823e5db1b74530ce85f17c3c5be5c85fc042ac939cbd909426e", size = 265125, upload-time = "2025-12-08T13:13:35.73Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/82b99223628b61300bd382c205795533bed021505eab6dd86e11fb5d7925/coverage-7.13.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:25dc33618d45456ccb1d37bce44bc78cf269909aa14c4db2e03d63146a8a1493", size = 259844, upload-time = "2025-12-08T13:13:37.69Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/2c/89b0291ae4e6cd59ef042708e1c438e2290f8c31959a20055d8768349ee2/coverage-7.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:71936a8b3b977ddd0b694c28c6a34f4fff2e9dd201969a4ff5d5fc7742d614b0", size = 262700, upload-time = "2025-12-08T13:13:39.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f9/a5f992efae1996245e796bae34ceb942b05db275e4b34222a9a40b9fbd3b/coverage-7.13.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:936bc20503ce24770c71938d1369461f0c5320830800933bc3956e2a4ded930e", size = 260321, upload-time = "2025-12-08T13:13:41.172Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/89/a29f5d98c64fedbe32e2ac3c227fbf78edc01cc7572eee17d61024d89889/coverage-7.13.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:af0a583efaacc52ae2521f8d7910aff65cdb093091d76291ac5820d5e947fc1c", size = 259222, upload-time = "2025-12-08T13:13:43.282Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c3/940fe447aae302a6701ee51e53af7e08b86ff6eed7631e5740c157ee22b9/coverage-7.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f1c23e24a7000da892a312fb17e33c5f94f8b001de44b7cf8ba2e36fbd15859e", size = 261411, upload-time = "2025-12-08T13:13:44.72Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/31/12a4aec689cb942a89129587860ed4d0fd522d5fda81237147fde554b8ae/coverage-7.13.0-cp313-cp313t-win32.whl", hash = "sha256:5f8a0297355e652001015e93be345ee54393e45dc3050af4a0475c5a2b767d46", size = 221505, upload-time = "2025-12-08T13:13:46.332Z" },
+    { url = "https://files.pythonhosted.org/packages/65/8c/3b5fe3259d863572d2b0827642c50c3855d26b3aefe80bdc9eba1f0af3b0/coverage-7.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6abb3a4c52f05e08460bd9acf04fec027f8718ecaa0d09c40ffbc3fbd70ecc39", size = 222569, upload-time = "2025-12-08T13:13:47.79Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/39/f71fa8316a96ac72fc3908839df651e8eccee650001a17f2c78cdb355624/coverage-7.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:3ad968d1e3aa6ce5be295ab5fe3ae1bf5bb4769d0f98a80a0252d543a2ef2e9e", size = 220841, upload-time = "2025-12-08T13:13:49.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4b/9b54bedda55421449811dcd5263a2798a63f48896c24dfb92b0f1b0845bd/coverage-7.13.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:453b7ec753cf5e4356e14fe858064e5520c460d3bbbcb9c35e55c0d21155c256", size = 218343, upload-time = "2025-12-08T13:13:50.811Z" },
+    { url = "https://files.pythonhosted.org/packages/59/df/c3a1f34d4bba2e592c8979f924da4d3d4598b0df2392fbddb7761258e3dc/coverage-7.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:af827b7cbb303e1befa6c4f94fd2bf72f108089cfa0f8abab8f4ca553cf5ca5a", size = 218672, upload-time = "2025-12-08T13:13:52.284Z" },
+    { url = "https://files.pythonhosted.org/packages/07/62/eec0659e47857698645ff4e6ad02e30186eb8afd65214fd43f02a76537cb/coverage-7.13.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9987a9e4f8197a1000280f7cc089e3ea2c8b3c0a64d750537809879a7b4ceaf9", size = 249715, upload-time = "2025-12-08T13:13:53.791Z" },
+    { url = "https://files.pythonhosted.org/packages/23/2d/3c7ff8b2e0e634c1f58d095f071f52ed3c23ff25be524b0ccae8b71f99f8/coverage-7.13.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3188936845cd0cb114fa6a51842a304cdbac2958145d03be2377ec41eb285d19", size = 252225, upload-time = "2025-12-08T13:13:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ac/fb03b469d20e9c9a81093575003f959cf91a4a517b783aab090e4538764b/coverage-7.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2bdb3babb74079f021696cb46b8bb5f5661165c385d3a238712b031a12355be", size = 253559, upload-time = "2025-12-08T13:13:57.161Z" },
+    { url = "https://files.pythonhosted.org/packages/29/62/14afa9e792383c66cc0a3b872a06ded6e4ed1079c7d35de274f11d27064e/coverage-7.13.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7464663eaca6adba4175f6c19354feea61ebbdd735563a03d1e472c7072d27bb", size = 249724, upload-time = "2025-12-08T13:13:58.692Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b7/333f3dab2939070613696ab3ee91738950f0467778c6e5a5052e840646b7/coverage-7.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8069e831f205d2ff1f3d355e82f511eb7c5522d7d413f5db5756b772ec8697f8", size = 251582, upload-time = "2025-12-08T13:14:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/81/cb/69162bda9381f39b2287265d7e29ee770f7c27c19f470164350a38318764/coverage-7.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6fb2d5d272341565f08e962cce14cdf843a08ac43bd621783527adb06b089c4b", size = 249538, upload-time = "2025-12-08T13:14:02.556Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/76/350387b56a30f4970abe32b90b2a434f87d29f8b7d4ae40d2e8a85aacfb3/coverage-7.13.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5e70f92ef89bac1ac8a99b3324923b4749f008fdbd7aa9cb35e01d7a284a04f9", size = 249349, upload-time = "2025-12-08T13:14:04.015Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0d/7f6c42b8d59f4c7e43ea3059f573c0dcfed98ba46eb43c68c69e52ae095c/coverage-7.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4b5de7d4583e60d5fd246dd57fcd3a8aa23c6e118a8c72b38adf666ba8e7e927", size = 251011, upload-time = "2025-12-08T13:14:05.505Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/f1/4bb2dff379721bb0b5c649d5c5eaf438462cad824acf32eb1b7ca0c7078e/coverage-7.13.0-cp314-cp314-win32.whl", hash = "sha256:a6c6e16b663be828a8f0b6c5027d36471d4a9f90d28444aa4ced4d48d7d6ae8f", size = 221091, upload-time = "2025-12-08T13:14:07.127Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/44/c239da52f373ce379c194b0ee3bcc121020e397242b85f99e0afc8615066/coverage-7.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:0900872f2fdb3ee5646b557918d02279dc3af3dfb39029ac4e945458b13f73bc", size = 221904, upload-time = "2025-12-08T13:14:08.542Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1f/b9f04016d2a29c2e4a0307baefefad1a4ec5724946a2b3e482690486cade/coverage-7.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:3a10260e6a152e5f03f26db4a407c4c62d3830b9af9b7c0450b183615f05d43b", size = 220480, upload-time = "2025-12-08T13:14:10.958Z" },
+    { url = "https://files.pythonhosted.org/packages/16/d4/364a1439766c8e8647860584171c36010ca3226e6e45b1753b1b249c5161/coverage-7.13.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9097818b6cc1cfb5f174e3263eba4a62a17683bcfe5c4b5d07f4c97fa51fbf28", size = 219074, upload-time = "2025-12-08T13:14:13.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f4/71ba8be63351e099911051b2089662c03d5671437a0ec2171823c8e03bec/coverage-7.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0018f73dfb4301a89292c73be6ba5f58722ff79f51593352759c1790ded1cabe", size = 219342, upload-time = "2025-12-08T13:14:15.02Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/25/127d8ed03d7711a387d96f132589057213e3aef7475afdaa303412463f22/coverage-7.13.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:166ad2a22ee770f5656e1257703139d3533b4a0b6909af67c6b4a3adc1c98657", size = 260713, upload-time = "2025-12-08T13:14:16.907Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/db/559fbb6def07d25b2243663b46ba9eb5a3c6586c0c6f4e62980a68f0ee1c/coverage-7.13.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f6aaef16d65d1787280943f1c8718dc32e9cf141014e4634d64446702d26e0ff", size = 262825, upload-time = "2025-12-08T13:14:18.68Z" },
+    { url = "https://files.pythonhosted.org/packages/37/99/6ee5bf7eff884766edb43bd8736b5e1c5144d0fe47498c3779326fe75a35/coverage-7.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e999e2dcc094002d6e2c7bbc1fb85b58ba4f465a760a8014d97619330cdbbbf3", size = 265233, upload-time = "2025-12-08T13:14:20.55Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/90/92f18fe0356ea69e1f98f688ed80cec39f44e9f09a1f26a1bbf017cc67f2/coverage-7.13.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:00c3d22cf6fb1cf3bf662aaaa4e563be8243a5ed2630339069799835a9cc7f9b", size = 259779, upload-time = "2025-12-08T13:14:22.367Z" },
+    { url = "https://files.pythonhosted.org/packages/90/5d/b312a8b45b37a42ea7d27d7d3ff98ade3a6c892dd48d1d503e773503373f/coverage-7.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:22ccfe8d9bb0d6134892cbe1262493a8c70d736b9df930f3f3afae0fe3ac924d", size = 262700, upload-time = "2025-12-08T13:14:24.309Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f8/b1d0de5c39351eb71c366f872376d09386640840a2e09b0d03973d791e20/coverage-7.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9372dff5ea15930fea0445eaf37bbbafbc771a49e70c0aeed8b4e2c2614cc00e", size = 260302, upload-time = "2025-12-08T13:14:26.068Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/7c/d42f4435bc40c55558b3109a39e2d456cddcec37434f62a1f1230991667a/coverage-7.13.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:69ac2c492918c2461bc6ace42d0479638e60719f2a4ef3f0815fa2df88e9f940", size = 259136, upload-time = "2025-12-08T13:14:27.604Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d3/23413241dc04d47cfe19b9a65b32a2edd67ecd0b817400c2843ebc58c847/coverage-7.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:739c6c051a7540608d097b8e13c76cfa85263ced467168dc6b477bae3df7d0e2", size = 261467, upload-time = "2025-12-08T13:14:29.09Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e6/6e063174500eee216b96272c0d1847bf215926786f85c2bd024cf4d02d2f/coverage-7.13.0-cp314-cp314t-win32.whl", hash = "sha256:fe81055d8c6c9de76d60c94ddea73c290b416e061d40d542b24a5871bad498b7", size = 221875, upload-time = "2025-12-08T13:14:31.106Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/46/f4fb293e4cbe3620e3ac2a3e8fd566ed33affb5861a9b20e3dd6c1896cbc/coverage-7.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:445badb539005283825959ac9fa4a28f712c214b65af3a2c464f1adc90f5fcbc", size = 222982, upload-time = "2025-12-08T13:14:33.1Z" },
+    { url = "https://files.pythonhosted.org/packages/68/62/5b3b9018215ed9733fbd1ae3b2ed75c5de62c3b55377a52cae732e1b7805/coverage-7.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:de7f6748b890708578fc4b7bb967d810aeb6fcc9bff4bb77dbca77dab2f9df6a", size = 221016, upload-time = "2025-12-08T13:14:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/4c/1968f32fb9a2604645827e11ff84a31e59d532e01995f904723b4f5328b3/coverage-7.13.0-py3-none-any.whl", hash = "sha256:850d2998f380b1e266459ca5b47bc9e7daf9af1d070f66317972f382d46f1904", size = 210068, upload-time = "2025-12-08T13:14:36.236Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -1614,6 +1740,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461, upload-time = "2025-01-03T18:51:54.306Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -3377,6 +3512,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3825,6 +3969,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz", hash = "sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6", size = 1099274, upload-time = "2025-09-21T04:11:06.277Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl", hash = "sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e", size = 113890, upload-time = "2025-09-21T04:11:04.117Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Related to #3 
- Add pytest and related dev dependencies to pyproject.toml
- Create docker-compose.test.yaml for containerized test execution
- Add Makefile targets: test, test-cov, test-file, test-match
- Add unit tests for:
  - utils/functions.py (84 tests)
  - utils/llms.py (72 tests including token counting)
  - utils/schemas.py (9 tests)
  - utils/k8s.py (17 tests)
  - backend/api.py (24 tests)
  - ce_tools/ (30 tests)
- Update test_kustomize_input.py to skip without API keys
- Update README with test documentation